### PR TITLE
Add notification workflows for build status

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,3 +57,17 @@ jobs:
 
       - name: Build and test
         run: mvn -U -B test verify
+
+  notify:
+    needs: [build]
+    if: failure() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/discord-notify.yml@main
+    secrets: inherit
+
+  notify-recovery:
+    needs: [build]
+    if: success() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/notify-recovery.yml@main
+    with:
+      branch: main
+    secrets: inherit


### PR DESCRIPTION
This pull request updates the `.github/workflows/maven.yml` workflow to add automated notifications for build failures and recoveries on the `main` branch. This helps ensure that the team is promptly informed of issues and their resolution.

**Workflow notification improvements:**

* Added a `notify` job that triggers a Discord notification when the build fails on the `main` branch, using a shared workflow for consistency.
* Added a `notify-recovery` job to send a recovery notification when the build succeeds again on the `main` branch, also using a shared workflow and passing the branch name as a parameter.