### PR TITLE
feat(repository): add activity-based session pagination

### DIFF
--- a/embabel-chat-store-autoconfigure/src/main/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreAutoConfiguration.kt
+++ b/embabel-chat-store-autoconfigure/src/main/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreAutoConfiguration.kt
@@ -125,7 +125,7 @@ open class ChatStoreAutoConfiguration {
         UniquenessConstraintSpec(label = "ChatSession", property = "sessionId"),
         UniquenessConstraintSpec(label = "StoredMessage", property = "messageId"),
         UniquenessConstraintSpec(label = "User", property = "id"),
-        RangeIndexSpec(label = "ChatSession", properties = listOf("lastActivityAt", "sessionId")),
+        RangeIndexSpec(label = "ChatSession", property = "lastActivityAt"),
     )
 
     /** Backfills activity for installations that predate most-recently-active ordering. */

--- a/embabel-chat-store-autoconfigure/src/main/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreAutoConfiguration.kt
+++ b/embabel-chat-store-autoconfigure/src/main/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreAutoConfiguration.kt
@@ -27,13 +27,17 @@ import com.embabel.chat.store.embedding.MessageEmbedder
 import com.embabel.chat.store.embedding.RoleFilteringMessageEmbedder
 import com.embabel.chat.store.event.SessionEventAwaiter
 import com.embabel.chat.store.repository.ChatSessionRepository
+import com.embabel.chat.store.repository.SessionActivityMigration
 import com.embabel.chat.support.InMemoryConversationFactory
+import org.drivine.manager.PersistenceManager
+import org.drivine.schema.RangeIndexSpec
 import org.drivine.schema.SchemaCatalog
 import org.drivine.schema.SimilarityFunction
 import org.drivine.schema.UniquenessConstraintSpec
 import org.drivine.schema.VectorIndexSpec
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -121,7 +125,17 @@ open class ChatStoreAutoConfiguration {
         UniquenessConstraintSpec(label = "ChatSession", property = "sessionId"),
         UniquenessConstraintSpec(label = "StoredMessage", property = "messageId"),
         UniquenessConstraintSpec(label = "User", property = "id"),
+        RangeIndexSpec(label = "ChatSession", properties = listOf("lastActivityAt", "sessionId")),
     )
+
+    /** Backfills activity for installations that predate most-recently-active ordering. */
+    @Bean
+    @ConditionalOnBean(PersistenceManager::class)
+    open fun chatStoreSessionActivityMigration(
+        persistenceManager: PersistenceManager,
+    ): ApplicationRunner = ApplicationRunner {
+        SessionActivityMigration(persistenceManager).migrate()
+    }
 
     /**
      * Declares the chat-message vector index, sized to the configured embedding model's

--- a/embabel-chat-store-autoconfigure/src/test/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreSchemaWiringTest.kt
+++ b/embabel-chat-store-autoconfigure/src/test/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreSchemaWiringTest.kt
@@ -62,7 +62,7 @@ class ChatStoreSchemaWiringTest {
             assertThat(constraintCatalog.constraints.map { (it as UniquenessConstraintSpec).label })
                 .containsExactlyInAnyOrder("ChatSession", "StoredMessage", "User")
             assertThat(constraintCatalog.indexes).containsExactly(
-                RangeIndexSpec("ChatSession", listOf("lastActivityAt", "sessionId"))
+                RangeIndexSpec("ChatSession", "lastActivityAt")
             )
 
             val vectorCatalog = context.getBean("chatStoreVectorIndexSchema", SchemaCatalog::class.java)
@@ -83,7 +83,7 @@ class ChatStoreSchemaWiringTest {
                 val catalogs = context.getBeansOfType(SchemaCatalog::class.java).values
                 assertThat(catalogs).hasSize(1)
                 assertThat(catalogs.single().indexes).containsExactly(
-                    RangeIndexSpec("ChatSession", listOf("lastActivityAt", "sessionId"))
+                    RangeIndexSpec("ChatSession", "lastActivityAt")
                 )
                 assertThat(catalogs.single().constraints).hasSize(3)
             }
@@ -95,7 +95,7 @@ class ChatStoreSchemaWiringTest {
             val catalogs = context.getBeansOfType(SchemaCatalog::class.java).values
             assertThat(catalogs).hasSize(1)
             assertThat(catalogs.single().indexes).containsExactly(
-                RangeIndexSpec("ChatSession", listOf("lastActivityAt", "sessionId"))
+                RangeIndexSpec("ChatSession", "lastActivityAt")
             )
             assertThat(catalogs.single().constraints).hasSize(3)
         }

--- a/embabel-chat-store-autoconfigure/src/test/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreSchemaWiringTest.kt
+++ b/embabel-chat-store-autoconfigure/src/test/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreSchemaWiringTest.kt
@@ -20,6 +20,7 @@ import com.embabel.chat.store.repository.ChatSessionRepository
 import com.embabel.common.ai.model.EmbeddingService
 import org.assertj.core.api.Assertions.assertThat
 import org.drivine.schema.SchemaCatalog
+import org.drivine.schema.RangeIndexSpec
 import org.drivine.schema.UniquenessConstraintSpec
 import org.drivine.schema.VectorIndexSpec
 import org.junit.jupiter.api.Test
@@ -57,11 +58,14 @@ class ChatStoreSchemaWiringTest {
             val catalogs = context.getBeansOfType(SchemaCatalog::class.java).values
             assertThat(catalogs).hasSize(2)
 
-            val constraintCatalog = catalogs.first { it.constraints.isNotEmpty() }
+            val constraintCatalog = context.getBean("chatStoreConstraintSchema", SchemaCatalog::class.java)
             assertThat(constraintCatalog.constraints.map { (it as UniquenessConstraintSpec).label })
                 .containsExactlyInAnyOrder("ChatSession", "StoredMessage", "User")
+            assertThat(constraintCatalog.indexes).containsExactly(
+                RangeIndexSpec("ChatSession", listOf("lastActivityAt", "sessionId"))
+            )
 
-            val vectorCatalog = catalogs.first { it.indexes.isNotEmpty() }
+            val vectorCatalog = context.getBean("chatStoreVectorIndexSchema", SchemaCatalog::class.java)
             val spec = vectorCatalog.indexes.single() as VectorIndexSpec
             assertThat(spec.label).isEqualTo("StoredMessage")
             assertThat(spec.property).isEqualTo("embedding")
@@ -78,7 +82,9 @@ class ChatStoreSchemaWiringTest {
             .run { context ->
                 val catalogs = context.getBeansOfType(SchemaCatalog::class.java).values
                 assertThat(catalogs).hasSize(1)
-                assertThat(catalogs.single().indexes).isEmpty()
+                assertThat(catalogs.single().indexes).containsExactly(
+                    RangeIndexSpec("ChatSession", listOf("lastActivityAt", "sessionId"))
+                )
                 assertThat(catalogs.single().constraints).hasSize(3)
             }
     }
@@ -88,7 +94,9 @@ class ChatStoreSchemaWiringTest {
         runner.run { context ->
             val catalogs = context.getBeansOfType(SchemaCatalog::class.java).values
             assertThat(catalogs).hasSize(1)
-            assertThat(catalogs.single().indexes).isEmpty()
+            assertThat(catalogs.single().indexes).containsExactly(
+                RangeIndexSpec("ChatSession", listOf("lastActivityAt", "sessionId"))
+            )
             assertThat(catalogs.single().constraints).hasSize(3)
         }
     }

--- a/embabel-chat-store/codegen-gradle/build.gradle.kts
+++ b/embabel-chat-store/codegen-gradle/build.gradle.kts
@@ -23,7 +23,7 @@ version = "0.5.0-SNAPSHOT"
 // later compiled against. Previously drivineVersion was hardcoded here, so bumping the pom silently
 // generated the DSL against a different Drivine than the one it compiled against. The fallbacks keep a
 // standalone `./gradlew kspKotlin` working.
-val drivineVersion = (findProperty("drivineVersion") as String?) ?: "0.0.74-SNAPSHOT"
+val drivineVersion = (findProperty("drivineVersion") as String?) ?: "0.0.74"
 val embabelAgentVersion = (findProperty("embabelAgentVersion") as String?) ?: "1.5.0-SNAPSHOT"
 val embabelCommonVersion = (findProperty("embabelCommonVersion") as String?) ?: "2.0.0-SNAPSHOT"
 

--- a/embabel-chat-store/codegen-gradle/build.gradle.kts
+++ b/embabel-chat-store/codegen-gradle/build.gradle.kts
@@ -23,7 +23,7 @@ version = "0.5.0-SNAPSHOT"
 // later compiled against. Previously drivineVersion was hardcoded here, so bumping the pom silently
 // generated the DSL against a different Drivine than the one it compiled against. The fallbacks keep a
 // standalone `./gradlew kspKotlin` working.
-val drivineVersion = (findProperty("drivineVersion") as String?) ?: "0.0.73"
+val drivineVersion = (findProperty("drivineVersion") as String?) ?: "0.0.74-SNAPSHOT"
 val embabelAgentVersion = (findProperty("embabelAgentVersion") as String?) ?: "1.5.0-SNAPSHOT"
 val embabelCommonVersion = (findProperty("embabelCommonVersion") as String?) ?: "2.0.0-SNAPSHOT"
 

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/model/SessionData.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/model/SessionData.kt
@@ -17,6 +17,7 @@ package com.embabel.chat.store.model
 
 import org.drivine.annotation.NodeFragment
 import org.drivine.annotation.NodeId
+import org.drivine.annotation.RangeIndex
 import java.time.Instant
 
 /**
@@ -26,6 +27,7 @@ import java.time.Instant
  * when sorted lexicographically.
  */
 @NodeFragment(labels = ["ChatSession"])
+@RangeIndex(properties = ["lastActivityAt", "sessionId"])
 data class SessionData(
     /**
      * Unique session identifier (UUIDv7 recommended).
@@ -41,6 +43,9 @@ data class SessionData(
      * When the session was created.
      */
     val createdAt: Instant,
+
+    /** Last user-visible conversation activity; used for stable session-list ordering. */
+    val lastActivityAt: Instant = createdAt,
 
     /**
      * Optional metadata for application-specific extensions.

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/model/SessionData.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/model/SessionData.kt
@@ -27,7 +27,7 @@ import java.time.Instant
  * when sorted lexicographically.
  */
 @NodeFragment(labels = ["ChatSession"])
-@RangeIndex(properties = ["lastActivityAt", "sessionId"])
+@RangeIndex(properties = ["lastActivityAt"])
 data class SessionData(
     /**
      * Unique session identifier (UUIDv7 recommended).

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepository.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepository.kt
@@ -83,6 +83,14 @@ interface ChatSessionRepository {
     fun listSessionsForUser(userId: String): List<StoredSession>
 
     /**
+     * List sessions in descending `(lastActivityAt, sessionId)` order using an opaque keyset cursor.
+     * The session ID is only a unique tie-breaker: arbitrary strings remain deterministic, while
+     * UUIDv7 is still recommended by the creation API. Concurrent activity may move a session ahead
+     * of an already-issued cursor; this method does not provide snapshot isolation across requests.
+     */
+    fun listSessionsForUser(userId: String, page: SessionPageRequest): SessionPage<StoredSession>
+
+    /**
      * List a user's sessions as lightweight summaries — owner plus a message count
      * computed in the query, without loading the messages. Suited to session-list
      * UIs that show a "N messages" badge but not the conversation bodies.
@@ -91,6 +99,11 @@ interface ChatSessionRepository {
      * @return one [SessionSummary] per owned session
      */
     fun listSessionSummariesForUser(userId: String): List<SessionSummary>
+
+    /**
+     * Lightweight equivalent of [listSessionsForUser] with identical ordering and cursor semantics.
+     */
+    fun listSessionSummariesForUser(userId: String, page: SessionPageRequest): SessionPage<SessionSummary>
 
     /**
      * Count the sessions owned by a user, without loading them.

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImpl.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImpl.kt
@@ -24,6 +24,7 @@ import com.embabel.chat.store.model.SessionData
 import com.embabel.chat.store.model.SessionParticipants
 import com.embabel.chat.store.model.SessionRef
 import com.embabel.chat.store.model.SessionSummary
+import com.embabel.chat.store.model.SessionSummaryQueryDsl
 import com.embabel.chat.store.model.SimpleStoredMessage
 import com.embabel.chat.store.model.StoredSession
 import com.embabel.chat.store.model.StoredSessionQueryDsl
@@ -35,11 +36,14 @@ import com.embabel.chat.store.model.loadAll
 import com.embabel.chat.store.model.owner
 import org.drivine.manager.CascadeType
 import org.drivine.manager.GraphObjectManager
+import org.drivine.manager.PersistenceManager
 import org.drivine.manager.delete
 import org.drivine.manager.load
+import org.drivine.query.QuerySpecification
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.Instant
 import java.util.Optional
 
@@ -51,7 +55,9 @@ import java.util.Optional
  */
 open class ChatSessionRepositoryImpl(
     private val graphObjectManager: GraphObjectManager,
-    private val eventPublisher: ApplicationEventPublisher? = null
+    private val persistenceManager: PersistenceManager,
+    private val eventPublisher: ApplicationEventPublisher? = null,
+    private val clock: Clock = Clock.systemUTC(),
 ) : ChatSessionRepository {
 
     private val logger = LoggerFactory.getLogger(ChatSessionRepositoryImpl::class.java)
@@ -60,11 +66,13 @@ open class ChatSessionRepositoryImpl(
     override fun createSession(sessionId: String, owner: StoredUser, title: String?): StoredSession {
         logger.debug("Creating session {} for owner {}", sessionId, owner.id)
 
+        val now = clock.instant()
         val session = StoredSession(
             session = SessionData(
                 sessionId = sessionId,
                 title = title,
-                createdAt = Instant.now()
+                createdAt = now,
+                lastActivityAt = now,
             ),
             owner = owner,
             messages = emptyList()
@@ -92,11 +100,13 @@ open class ChatSessionRepositoryImpl(
             recipient = messageRecipient
         )
 
+        val now = clock.instant()
         val session = StoredSession(
             session = SessionData(
                 sessionId = sessionId,
                 title = title,
-                createdAt = Instant.now()
+                createdAt = now,
+                lastActivityAt = now,
             ),
             owner = owner,
             messages = listOf(message)
@@ -120,8 +130,32 @@ open class ChatSessionRepositoryImpl(
             where {
                 owner.id eq userId
             }
+            orderBy(
+                StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.desc(),
+                StoredSessionQueryDsl.INSTANCE.session.sessionId.desc(),
+            )
         }
     }
+
+    @Transactional(readOnly = true)
+    override fun listSessionsForUser(userId: String, page: SessionPageRequest): SessionPage<StoredSession> =
+        loadSessionPage(page, loader = {
+            graphObjectManager.loadAll<StoredSession> {
+                where { owner.id eq userId }
+                orderBy(
+                    StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.desc(),
+                    StoredSessionQueryDsl.INSTANCE.session.sessionId.desc(),
+                )
+                page.cursor?.let { encoded ->
+                    val cursor = SessionCursorCodec.decode(encoded)
+                    seekAfter(
+                        StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.after(cursor.lastActivityAt),
+                        StoredSessionQueryDsl.INSTANCE.session.sessionId.after(cursor.sessionId),
+                    )
+                }
+                limit(page.pageSize + 1)
+            }
+        }, sessionData = { it.session })
 
     @Transactional(readOnly = true)
     override fun listSessionSummariesForUser(userId: String): List<SessionSummary> {
@@ -131,8 +165,34 @@ open class ChatSessionRepositoryImpl(
             where {
                 owner.id eq userId
             }
+            orderBy(
+                SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.desc(),
+                SessionSummaryQueryDsl.INSTANCE.session.sessionId.desc(),
+            )
         }
     }
+
+    @Transactional(readOnly = true)
+    override fun listSessionSummariesForUser(
+        userId: String,
+        page: SessionPageRequest,
+    ): SessionPage<SessionSummary> = loadSessionPage(page, loader = {
+        graphObjectManager.loadAll<SessionSummary> {
+            where { owner.id eq userId }
+            orderBy(
+                SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.desc(),
+                SessionSummaryQueryDsl.INSTANCE.session.sessionId.desc(),
+            )
+            page.cursor?.let { encoded ->
+                val cursor = SessionCursorCodec.decode(encoded)
+                seekAfter(
+                    SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.after(cursor.lastActivityAt),
+                    SessionSummaryQueryDsl.INSTANCE.session.sessionId.after(cursor.sessionId),
+                )
+            }
+            limit(page.pageSize + 1)
+        }
+    }, sessionData = { it.session })
 
     @Transactional(readOnly = true)
     override fun countSessionsForUser(userId: String): Long {
@@ -173,7 +233,7 @@ open class ChatSessionRepositoryImpl(
         logger.debug("Adding message {} to session {}", messageData.messageId, sessionId)
 
         // Verify session exists — MERGE on SessionRef would silently create a bare node
-        if (graphObjectManager.load<StoredSession>(sessionId) == null) {
+        if (graphObjectManager.load<SessionRef>(sessionId) == null) {
             throw IllegalArgumentException("Session not found: $sessionId")
         }
 
@@ -186,6 +246,7 @@ open class ChatSessionRepositoryImpl(
             )
         )
         graphObjectManager.save(newMessage, CascadeType.PRESERVE)
+        advanceActivity(sessionId, clock.instant())
 
         return findBySessionId(sessionId).orElseThrow {
             IllegalStateException("Session not found after adding message: $sessionId")
@@ -231,5 +292,35 @@ open class ChatSessionRepositoryImpl(
     @Transactional
     override fun deleteAll() {
         graphObjectManager.deleteAll<StoredSession> { }
+    }
+
+    private fun advanceActivity(sessionId: String, activityAt: Instant) {
+        persistenceManager.execute(
+            QuerySpecification
+                .withStatement(
+                    """
+                    MATCH (session:ChatSession {sessionId: ${'$'}sessionId})
+                    SET session.lastActivityAt = CASE
+                        WHEN session.lastActivityAt IS NULL OR session.lastActivityAt < ${'$'}activityAt
+                        THEN ${'$'}activityAt ELSE session.lastActivityAt END
+                    """.trimIndent()
+                )
+                .bind(mapOf("sessionId" to sessionId, "activityAt" to activityAt))
+        )
+    }
+
+    private fun <T> loadSessionPage(
+        page: SessionPageRequest,
+        loader: () -> List<T>,
+        sessionData: (T) -> SessionData,
+    ): SessionPage<T> {
+        val loaded = loader()
+        val items = loaded.take(page.pageSize)
+        val nextCursor = if (loaded.size > page.pageSize) {
+            items.lastOrNull()?.let(sessionData)?.let {
+                SessionCursorCodec.encode(SessionCursor(it.lastActivityAt, it.sessionId))
+            }
+        } else null
+        return SessionPage(items, nextCursor)
     }
 }

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImpl.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImpl.kt
@@ -40,12 +40,21 @@ import org.drivine.manager.PersistenceManager
 import org.drivine.manager.delete
 import org.drivine.manager.load
 import org.drivine.query.QuerySpecification
+import org.drivine.query.dsl.OrderBuilder
+import org.drivine.query.dsl.OrderSpec
+import org.drivine.query.dsl.query
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.time.Instant
 import java.util.Optional
+
+/** Registers a typed order built outside the block to disambiguate Drivine's binary `asc`/`desc` overloads. */
+context(builder: OrderBuilder<*>)
+private fun registerOrder(order: OrderSpec) {
+    builder(order)
+}
 
 /**
  * Drivine-based implementation of ChatSessionRepository.
@@ -126,49 +135,56 @@ open class ChatSessionRepositoryImpl(
 
     @Transactional(readOnly = true)
     override fun listSessionsForUser(userId: String): List<StoredSession> {
+        val lastActivityOrder = StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.desc()
+        val sessionIdOrder = StoredSessionQueryDsl.INSTANCE.session.sessionId.desc()
         return graphObjectManager.loadAll<StoredSession> {
             where {
                 owner.id eq userId
             }
-            orderBy(
-                StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.desc(),
-                StoredSessionQueryDsl.INSTANCE.session.sessionId.desc(),
-            )
+            orderBy {
+                registerOrder(lastActivityOrder)
+                registerOrder(sessionIdOrder)
+            }
         }
     }
 
     @Transactional(readOnly = true)
-    override fun listSessionsForUser(userId: String, page: SessionPageRequest): SessionPage<StoredSession> =
-        loadSessionPage(page, loader = {
+    override fun listSessionsForUser(userId: String, page: SessionPageRequest): SessionPage<StoredSession> {
+        val lastActivityOrder = StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.desc()
+        val sessionIdOrder = StoredSessionQueryDsl.INSTANCE.session.sessionId.desc()
+        return loadSessionPage(page, loader = {
             graphObjectManager.loadAll<StoredSession> {
                 where { owner.id eq userId }
-                orderBy(
-                    StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.desc(),
-                    StoredSessionQueryDsl.INSTANCE.session.sessionId.desc(),
-                )
+                orderBy {
+                    registerOrder(lastActivityOrder)
+                    registerOrder(sessionIdOrder)
+                }
                 page.cursor?.let { encoded ->
                     val cursor = SessionCursorCodec.decode(encoded)
-                    seekAfter(
-                        StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.after(cursor.lastActivityAt),
-                        StoredSessionQueryDsl.INSTANCE.session.sessionId.after(cursor.sessionId),
-                    )
+                    seek {
+                        query.session.lastActivityAt after cursor.lastActivityAt
+                        query.session.sessionId after cursor.sessionId
+                    }
                 }
                 limit(page.pageSize + 1)
             }
         }, sessionData = { it.session })
+    }
 
     @Transactional(readOnly = true)
     override fun listSessionSummariesForUser(userId: String): List<SessionSummary> {
+        val lastActivityOrder = SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.desc()
+        val sessionIdOrder = SessionSummaryQueryDsl.INSTANCE.session.sessionId.desc()
         // SessionSummary folds the message count into the query (via @Count), so this
         // returns one flat row per session — no message bodies cross the wire.
         return graphObjectManager.loadAll<SessionSummary> {
             where {
                 owner.id eq userId
             }
-            orderBy(
-                SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.desc(),
-                SessionSummaryQueryDsl.INSTANCE.session.sessionId.desc(),
-            )
+            orderBy {
+                registerOrder(lastActivityOrder)
+                registerOrder(sessionIdOrder)
+            }
         }
     }
 
@@ -176,23 +192,27 @@ open class ChatSessionRepositoryImpl(
     override fun listSessionSummariesForUser(
         userId: String,
         page: SessionPageRequest,
-    ): SessionPage<SessionSummary> = loadSessionPage(page, loader = {
-        graphObjectManager.loadAll<SessionSummary> {
-            where { owner.id eq userId }
-            orderBy(
-                SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.desc(),
-                SessionSummaryQueryDsl.INSTANCE.session.sessionId.desc(),
-            )
-            page.cursor?.let { encoded ->
-                val cursor = SessionCursorCodec.decode(encoded)
-                seekAfter(
-                    SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.after(cursor.lastActivityAt),
-                    SessionSummaryQueryDsl.INSTANCE.session.sessionId.after(cursor.sessionId),
-                )
+    ): SessionPage<SessionSummary> {
+        val lastActivityOrder = SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.desc()
+        val sessionIdOrder = SessionSummaryQueryDsl.INSTANCE.session.sessionId.desc()
+        return loadSessionPage(page, loader = {
+            graphObjectManager.loadAll<SessionSummary> {
+                where { owner.id eq userId }
+                orderBy {
+                    registerOrder(lastActivityOrder)
+                    registerOrder(sessionIdOrder)
+                }
+                page.cursor?.let { encoded ->
+                    val cursor = SessionCursorCodec.decode(encoded)
+                    seek {
+                        query.session.lastActivityAt after cursor.lastActivityAt
+                        query.session.sessionId after cursor.sessionId
+                    }
+                }
+                limit(page.pageSize + 1)
             }
-            limit(page.pageSize + 1)
-        }
-    }, sessionData = { it.session })
+        }, sessionData = { it.session })
+    }
 
     @Transactional(readOnly = true)
     override fun countSessionsForUser(userId: String): Long {

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionActivityMigration.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionActivityMigration.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.store.repository
+
+import org.drivine.manager.PersistenceManager
+import org.drivine.query.QuerySpecification
+
+/** Idempotently backfills activity timestamps for sessions created before activity ordering existed. */
+class SessionActivityMigration(
+    private val persistenceManager: PersistenceManager,
+) {
+    fun migrate() {
+        persistenceManager.execute(
+            QuerySpecification.withStatement(
+                """
+                MATCH (session:ChatSession)
+                WHERE session.lastActivityAt IS NULL
+                OPTIONAL MATCH (session)-[:HAS_MESSAGE]->(message:StoredMessage)
+                WITH session, max(message.createdAt) AS latestMessageAt
+                SET session.lastActivityAt = coalesce(latestMessageAt, session.createdAt)
+                """.trimIndent()
+            )
+        )
+    }
+}

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionCursorCodec.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionCursorCodec.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.store.repository
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.Base64
+
+internal data class SessionCursor(
+    val lastActivityAt: Instant,
+    val sessionId: String,
+)
+
+/** Versioned binary cursor encoding; callers treat the resulting Base64URL value as opaque. */
+internal object SessionCursorCodec {
+    private const val VERSION: Byte = 1
+    private const val HEADER_SIZE = 1 + Long.SIZE_BYTES + Int.SIZE_BYTES + Int.SIZE_BYTES
+    private const val MAX_SESSION_ID_BYTES = 16 * 1024
+
+    fun encode(cursor: SessionCursor): String {
+        val idBytes = cursor.sessionId.toByteArray(StandardCharsets.UTF_8)
+        require(idBytes.size <= MAX_SESSION_ID_BYTES) { "sessionId is too large to encode in a cursor" }
+        val bytes = ByteBuffer.allocate(HEADER_SIZE + idBytes.size)
+            .put(VERSION)
+            .putLong(cursor.lastActivityAt.epochSecond)
+            .putInt(cursor.lastActivityAt.nano)
+            .putInt(idBytes.size)
+            .put(idBytes)
+            .array()
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    fun decode(encoded: String): SessionCursor {
+        try {
+            val bytes = Base64.getUrlDecoder().decode(encoded)
+            require(bytes.size >= HEADER_SIZE) { "cursor payload is truncated" }
+            val buffer = ByteBuffer.wrap(bytes)
+            require(buffer.get() == VERSION) { "unsupported cursor version" }
+            val epochSecond = buffer.long
+            val nano = buffer.int
+            require(nano in 0..999_999_999) { "invalid cursor timestamp" }
+            val idLength = buffer.int
+            require(idLength in 0..MAX_SESSION_ID_BYTES && idLength == buffer.remaining()) {
+                "invalid cursor session ID length"
+            }
+            val idBytes = ByteArray(idLength)
+            buffer.get(idBytes)
+            val sessionId = String(idBytes, StandardCharsets.UTF_8)
+            require(sessionId.isNotEmpty()) { "cursor session ID is empty" }
+            return SessionCursor(Instant.ofEpochSecond(epochSecond, nano.toLong()), sessionId)
+        } catch (cause: Exception) {
+            if (cause is IllegalArgumentException && cause.message == "Invalid session cursor") throw cause
+            throw IllegalArgumentException("Invalid session cursor", cause)
+        }
+    }
+}

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionPage.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionPage.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.store.repository
+
+/** Request for one cursor-based page of sessions. */
+data class SessionPageRequest(
+    val pageSize: Int = DEFAULT_PAGE_SIZE,
+    val cursor: String? = null,
+) {
+    init {
+        require(pageSize in 1..MAX_PAGE_SIZE) {
+            "pageSize must be between 1 and $MAX_PAGE_SIZE, was $pageSize"
+        }
+        require(cursor == null || cursor.isNotBlank()) { "cursor must be null or non-blank" }
+    }
+
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 20
+        const val MAX_PAGE_SIZE = 100
+    }
+}
+
+/** A page of sessions and the opaque cursor for the following page, if one exists. */
+data class SessionPage<T>(
+    val items: List<T>,
+    val nextCursor: String?,
+)

--- a/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/TestConfiguration.kt
+++ b/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/TestConfiguration.kt
@@ -66,7 +66,10 @@ class TestApplication {
     }
 
     @Bean
-    fun chatSessionRepository(graphObjectManager: GraphObjectManager): ChatSessionRepository {
-        return ChatSessionRepositoryImpl(graphObjectManager)
+    fun chatSessionRepository(
+        graphObjectManager: GraphObjectManager,
+        persistenceManager: PersistenceManager,
+    ): ChatSessionRepository {
+        return ChatSessionRepositoryImpl(graphObjectManager, persistenceManager)
     }
 }

--- a/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImplTest.kt
+++ b/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImplTest.kt
@@ -28,7 +28,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 
 /**
@@ -79,8 +81,117 @@ class ChatSessionRepositoryImplTest {
         assertEquals(sessionId, created.session.sessionId)
         assertEquals("Test Session", created.session.title)
         assertNotNull(created.session.createdAt)
+        assertEquals(created.session.createdAt, created.session.lastActivityAt)
         assertEquals(testUser.id, created.owner.id)
         assertTrue(created.messages.isEmpty())
+    }
+
+    @Test
+    fun `pages sessions by activity with session ID as deterministic tie breaker`() {
+        val timestamps = mapOf(
+            "session-a" to Instant.parse("2026-01-01T00:00:01Z"),
+            "session-b" to Instant.parse("2026-01-01T00:00:03Z"),
+            "session-c" to Instant.parse("2026-01-01T00:00:03Z"),
+            "session-d" to Instant.parse("2026-01-01T00:00:02Z"),
+            "session-e" to Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        timestamps.forEach { (id, activity) ->
+            chatSessionRepository.createSession(id, testUser, id)
+            setActivity(id, activity)
+        }
+
+        val first = chatSessionRepository.listSessionsForUser(testUser.id, SessionPageRequest(pageSize = 2))
+        val second = chatSessionRepository.listSessionsForUser(
+            testUser.id,
+            SessionPageRequest(pageSize = 2, cursor = first.nextCursor),
+        )
+        val third = chatSessionRepository.listSessionsForUser(
+            testUser.id,
+            SessionPageRequest(pageSize = 2, cursor = second.nextCursor),
+        )
+
+        assertEquals(listOf("session-c", "session-b"), first.items.map { it.session.sessionId })
+        assertEquals(listOf("session-d", "session-a"), second.items.map { it.session.sessionId })
+        assertEquals(listOf("session-e"), third.items.map { it.session.sessionId })
+        assertNotNull(first.nextCursor)
+        assertNotNull(second.nextCursor)
+        assertNull(third.nextCursor)
+    }
+
+    @Test
+    fun `summary pagination has the same ordering and remains scoped to owner`() {
+        val other = TestSessionUser(UUID.randomUUID().toString(), "Other User")
+        graphObjectManager.save(other)
+        chatSessionRepository.createSession("mine-old", testUser)
+        chatSessionRepository.createSession("mine-new", testUser)
+        chatSessionRepository.createSession("theirs", other)
+        setActivity("mine-old", Instant.parse("2026-01-01T00:00:00Z"))
+        setActivity("mine-new", Instant.parse("2026-01-02T00:00:00Z"))
+        setActivity("theirs", Instant.parse("2026-01-03T00:00:00Z"))
+
+        val first = chatSessionRepository.listSessionSummariesForUser(
+            testUser.id,
+            SessionPageRequest(pageSize = 1),
+        )
+        val second = chatSessionRepository.listSessionSummariesForUser(
+            testUser.id,
+            SessionPageRequest(pageSize = 1, cursor = first.nextCursor),
+        )
+
+        assertEquals(listOf("mine-new"), first.items.map { it.session.sessionId })
+        assertEquals(listOf("mine-old"), second.items.map { it.session.sessionId })
+        assertNull(second.nextCursor)
+    }
+
+    @Test
+    fun `activity migration backfills latest message and is idempotent`() {
+        val sessionId = UUID.randomUUID().toString()
+        chatSessionRepository.createSession(sessionId, testUser)
+        val latest = Instant.parse("2026-02-03T04:05:06Z")
+        persistenceManager.execute(
+            QuerySpecification.withStatement(
+                "MATCH (s:ChatSession {sessionId: \$id}) SET s.lastActivityAt = null"
+            ).bind(mapOf("id" to sessionId))
+        )
+        chatSessionRepository.addMessage(
+            sessionId,
+            MessageData(UUID.randomUUID().toString(), MessageRole.USER, "hi", latest),
+        )
+        persistenceManager.execute(
+            QuerySpecification.withStatement(
+                "MATCH (s:ChatSession {sessionId: \$id}) SET s.lastActivityAt = null"
+            ).bind(mapOf("id" to sessionId))
+        )
+
+        SessionActivityMigration(persistenceManager).migrate()
+        SessionActivityMigration(persistenceManager).migrate()
+
+        assertEquals(latest, chatSessionRepository.findBySessionId(sessionId).get().session.lastActivityAt)
+    }
+
+    @Test
+    fun `message writes advance activity monotonically by write time`() {
+        val sessionId = UUID.randomUUID().toString()
+        val createdAt = Instant.parse("2026-01-01T00:00:00Z")
+        val activeAt = Instant.parse("2026-01-03T00:00:00Z")
+        val staleWriterTime = Instant.parse("2026-01-02T00:00:00Z")
+        fun repositoryAt(instant: Instant) = ChatSessionRepositoryImpl(
+            graphObjectManager,
+            persistenceManager,
+            clock = Clock.fixed(instant, ZoneOffset.UTC),
+        )
+
+        repositoryAt(createdAt).createSession(sessionId, testUser)
+        repositoryAt(activeAt).addMessage(
+            sessionId,
+            MessageData(UUID.randomUUID().toString(), MessageRole.USER, "newer write", createdAt),
+        )
+        repositoryAt(staleWriterTime).addMessage(
+            sessionId,
+            MessageData(UUID.randomUUID().toString(), MessageRole.USER, "stale writer", activeAt.plusSeconds(10)),
+        )
+
+        assertEquals(activeAt, chatSessionRepository.findBySessionId(sessionId).get().session.lastActivityAt)
     }
 
     @Test
@@ -420,6 +531,16 @@ class ChatSessionRepositoryImplTest {
                 .bind(mapOf("id" to id))
                 .transform(Int::class.java)
         )
+
+    private fun setActivity(sessionId: String, activityAt: Instant) {
+        persistenceManager.execute(
+            QuerySpecification
+                .withStatement(
+                    "MATCH (s:ChatSession {sessionId: \$sessionId}) SET s.lastActivityAt = \$activityAt"
+                )
+                .bind(mapOf("sessionId" to sessionId, "activityAt" to activityAt))
+        )
+    }
 
     @Test
     fun `test add message to session with author`() {

--- a/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/repository/SessionCursorCodecTest.kt
+++ b/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/repository/SessionCursorCodecTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.store.repository
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class SessionCursorCodecTest {
+
+    @Test
+    fun `cursor round trips timestamp precision and arbitrary session IDs`() {
+        val cursor = SessionCursor(Instant.parse("2026-08-04T12:34:56.123456789Z"), "not-a-uuid/✓")
+
+        assertEquals(cursor, SessionCursorCodec.decode(SessionCursorCodec.encode(cursor)))
+    }
+
+    @Test
+    fun `malformed cursors fail with a stable public error`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            SessionCursorCodec.decode("not a cursor")
+        }
+
+        assertEquals("Invalid session cursor", exception.message)
+    }
+
+    @Test
+    fun `page request enforces safe bounds`() {
+        assertThrows(IllegalArgumentException::class.java) { SessionPageRequest(pageSize = 0) }
+        assertThrows(IllegalArgumentException::class.java) { SessionPageRequest(pageSize = 101) }
+        assertThrows(IllegalArgumentException::class.java) { SessionPageRequest(cursor = " ") }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </modules>
 
     <properties>
-        <drivine.version>0.0.74-SNAPSHOT</drivine.version>
+        <drivine.version>0.0.74</drivine.version>
         <embabel-common.version>2.0.0-SNAPSHOT</embabel-common.version>
         <embabel-agent.version>1.5.0-SNAPSHOT</embabel-agent.version>
         <!-- Overrides the parent's default (2.2.21): the Drivine KSP-generated DSL uses context

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </modules>
 
     <properties>
-        <drivine.version>0.0.73</drivine.version>
+        <drivine.version>0.0.74-SNAPSHOT</drivine.version>
         <embabel-common.version>2.0.0-SNAPSHOT</embabel-common.version>
         <embabel-agent.version>1.5.0-SNAPSHOT</embabel-agent.version>
         <!-- Overrides the parent's default (2.2.21): the Drivine KSP-generated DSL uses context


### PR DESCRIPTION
## Description

  Closes #10.

  Adds cursor-based keyset pagination to the chat repository API.

  Sessions are ordered by most recent conversation activity using the
  deterministic compound ordering:

  `lastActivityAt DESC, sessionId DESC`

  The implementation uses Drivine4j 0.0.74's first-class keyset pagination
  support and exposes versioned opaque cursors to callers.

  ## Changes

  ### Pagination API

  Adds paginated overloads for both full sessions and session summaries:

  ```kotlin
  fun listSessionsForUser(
      userId: String,
      page: SessionPageRequest,
  ): SessionPage<StoredSession>

  fun listSessionSummariesForUser(
      userId: String,
      page: SessionPageRequest,
  ): SessionPage<SessionSummary>
  ```

  The existing non-paginated methods remain available, making this a
  non-breaking API addition.

  SessionPageRequest accepts:

  - A validated page size.
  - An optional opaque continuation cursor.

  SessionPage returns:

  - The current page of items.
  - A nullable cursor for the next page.

  The repository requests pageSize + 1 records to determine whether another
  page exists without issuing a separate count query.

  ### Ordering semantics

  Sessions are ordered by:

  1. lastActivityAt DESC
  2. sessionId DESC

  lastActivityAt reflects user-visible conversation activity. It is:

  - Initialized from the repository clock when a session is created.
  - Advanced when a message is added.
  - Updated monotonically, preventing an older or delayed writer from moving
    the session backwards in the ordering.

  - Backfilled for existing sessions from the latest message timestamp, or
    from createdAt when the session has no messages.

  sessionId is the unique tie-breaker and guarantees deterministic
  pagination even when multiple sessions have identical activity timestamps.

  The repository still accepts arbitrary session ID strings. UUIDv7 remains
  recommended, but no breaking validation has been introduced. Arbitrary
  strings provide deterministic tie-breaking; UUIDv7 additionally gives
  chronological tie ordering when activity timestamps are equal.

  Most-recently-active pagination does not provide snapshot isolation across
  requests. If a session receives new activity after a cursor is issued, it
  may move ahead of that cursor and therefore not appear in the continuation
  page. This is the expected behavior for a live recent-activity feed.

  ### Cursor format

  The cursor is an opaque, URL-safe Base64 value containing:

  - A format version.
  - The complete lastActivityAt value, including nanoseconds.
  - The session ID tie-breaker.

  The codec validates:

  - Base64 encoding.
  - Cursor version.
  - Payload length.
  - Timestamp nanoseconds.
  - Session ID length and UTF-8 encoding.
  - Trailing or truncated data.

  Callers should treat the cursor as opaque and should not construct or
  interpret it themselves.

  ### Persistence and indexing

  Adds a non-null lastActivityAt property to ChatSession.

  Adds a single-property range index on:

  ChatSession(lastActivityAt)

  This follows the Drivine4j keyset-pagination guidance. Neo4j can use this
  leading-property index for the range bound generated by the seek predicate.
  A composite (lastActivityAt, sessionId) index alone does not enable the
  same range seek.

  sessionId is already covered by the existing uniqueness constraint.

  An idempotent startup migration backfills lastActivityAt for installations
  created before this property existed.

  ### Drivine4j integration

  Updates the project to released Drivine4j 0.0.74 and uses:

  seek {
      query.session.lastActivityAt after cursor.lastActivityAt
      query.session.sessionId after cursor.sessionId
  }

  The Maven build and standalone Gradle code-generation build now resolve the
  same Drivine4j version.

  Drivine4j 0.0.74 exposes both legacy and context-aware binary asc/desc
  overloads, which are ambiguous to the downstream Kotlin Maven compiler.
  Ordering specifications are therefore created from typed property references
  outside the context block and registered through a small local adapter. This
  keeps the implementation type-safe and introduces no handwritten Cypher
  property paths.

  ## Testing

  Executed under Java 21:

  mvn -U -B test verify

  Results:

  - Embabel Chat Store: 82 tests passed
  - Embabel Chat Store Autoconfigure: 3 tests passed
  - Total: 85 tests passed
  - Failures: 0
  - Errors: 0
  - Skipped: 0

  Also verified:

  mvn -B spotless:check

  Test coverage includes:

  - Initial activity timestamps.
  - Activity backfill and migration idempotency.
  - Monotonic activity updates.
  - Most-recently-active ordering.
  - Stable ordering for equal timestamps.
  - Multi-page cursor traversal.
  - Pagination of full sessions.
  - Pagination of session summaries.
  - User isolation.
  - Invalid page sizes.
  - Malformed, truncated, and unsupported cursors.
  - Nanosecond timestamp preservation.
  - Schema catalog registration of the required range index.

  ## Additional Notes

  The build continues to report five pre-existing JUnit discovery warnings for
  embedding tests whose @Test methods return values. Those methods are
  unrelated to this change and were already not being executed by JUnit.