### PR TITLE
feat(repository): creation-ordered pagination, message-id narration, and #15 follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,92 @@ Planned support for:
 - Agent-to-agent communication patterns
 - Broadcast messages
 
+## Sorting and Pagination
+
+### Two orderings
+
+Session listings support two orderings, selected with `SessionOrder`:
+
+| `SessionOrder`  | Keyset                          | Meaning                        |
+|-----------------|---------------------------------|--------------------------------|
+| `CREATED`       | `sessionId`                     | Newest-created first (default) |
+| `LAST_ACTIVITY` | `(lastActivityAt, sessionId)`   | Most recently active first     |
+
+`CREATED` keys on the session ID alone. Session IDs are UUIDv7, which embeds a millisecond
+timestamp in the leading 48 bits, and the canonical string form is big-endian hex — so
+lexicographic comparison *is* chronological comparison. The ID is unique, so this is already
+a total order and needs no tie-breaker, and it is served by the index backing the `sessionId`
+uniqueness constraint. Two sessions created in the same millisecond order by the random bits
+rather than by true creation time: arbitrary, but stable.
+
+`LAST_ACTIVITY` orders by `lastActivityAt` descending, with `sessionId` descending purely as
+a tie-breaker — the ID is not the primary sort key here.
+
+Message order *within* a thread is always by `messageId` and is not configurable. Since
+message IDs are also UUIDv7, a thread always reads in the order it happened.
+
+### What counts as activity
+
+`lastActivityAt` advances **only when a message is added**. It is deliberately not touched by:
+
+- narration (`updateMessageNarration`)
+- title generation or renaming
+- any other enrichment of an existing message
+
+Editing or annotating a message should not jump its session to the top of a list, any more
+than it should move the message within its thread. The timestamp is also monotonic — it only
+ever moves forward — so clock skew between application instances can leave ordering slightly
+stale but can never move a session backwards, which would let a keyset walk skip or repeat it.
+
+### Paging
+
+Paging is keyset-based, not offset-based, so page *n* costs the same as page 1:
+
+```kotlin
+var cursor: String? = null
+do {
+    val page = repository.listSessionsForUser(
+        userId,
+        SessionPageRequest(pageSize = 20, cursor = cursor, order = SessionOrder.CREATED),
+    )
+    page.items.forEach { render(it) }
+    cursor = page.nextCursor
+} while (cursor != null)
+```
+
+`nextCursor` is null on the last page. Use `listSessionSummariesForUser` for the same paging
+over lightweight summaries — owner plus a message count computed in the query, without
+loading message bodies.
+
+Cursors are **opaque**: a versioned, Base64URL-encoded binary payload. Do not parse or
+construct them. Each cursor also records the `SessionOrder` that issued it, and is rejected
+if replayed against the other ordering — the two key on different properties, so silently
+seeking on the wrong one would return a plausible but wrong page.
+
+There is no snapshot isolation across requests. Under `LAST_ACTIVITY`, a session that becomes
+active mid-walk can move ahead of a cursor already issued and so be seen twice or missed.
+`CREATED` keys on an immutable value and does not have this property.
+
+### Upgrading from before `lastActivityAt`
+
+`SessionData.lastActivityAt` carries Drivine's `@Default`, so a session stored before the
+property existed hydrates as its `createdAt` instead of failing to load. Old data therefore
+stays readable with no migration, and sorts sensibly under `CREATED` — which is another reason
+that is the default ordering.
+
+`LAST_ACTIVITY` needs more: a keyset comparison is never satisfied by a value that is absent in
+the graph, so a session whose property is only defaulted client-side would still drop out of
+every page after the first. `SessionActivityMigration` materialises it, and the
+auto-configuration runs it on startup. It works in bounded batches (the un-backfilled set
+cannot use the range index, since Neo4j does not index nulls), coalesces to an epoch floor so
+sessions with neither messages nor a `createdAt` still converge, and records a marker node so
+later boots cost a single lookup rather than a full label scan. Any session that receives a
+message also repairs itself, since the write advances `lastActivityAt` when it is missing.
+
+So the backfill is a correctness step for one ordering, not a prerequisite for reading. If no
+`PersistenceManager` bean is present it cannot run, and the auto-configuration logs a warning
+saying so; `CREATED` is unaffected either way.
+
 ## Auto Title Generation
 
 Provide a `TitleGenerator` to automatically generate session titles:

--- a/embabel-chat-store-autoconfigure/src/main/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreAutoConfiguration.kt
+++ b/embabel-chat-store-autoconfigure/src/main/kotlin/com/embabel/chat/store/autoconfigure/ChatStoreAutoConfiguration.kt
@@ -28,6 +28,7 @@ import com.embabel.chat.store.embedding.RoleFilteringMessageEmbedder
 import com.embabel.chat.store.event.SessionEventAwaiter
 import com.embabel.chat.store.repository.ChatSessionRepository
 import com.embabel.chat.store.repository.SessionActivityMigration
+import com.embabel.chat.store.repository.SessionOrder
 import com.embabel.chat.support.InMemoryConversationFactory
 import org.drivine.manager.PersistenceManager
 import org.drivine.schema.RangeIndexSpec
@@ -36,6 +37,7 @@ import org.drivine.schema.SimilarityFunction
 import org.drivine.schema.UniquenessConstraintSpec
 import org.drivine.schema.VectorIndexSpec
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -129,13 +131,29 @@ open class ChatStoreAutoConfiguration {
         RangeIndexSpec(label = "ChatSession", property = "lastActivityAt"),
     )
 
-    /** Backfills activity for installations that predate most-recently-active ordering. */
+    /**
+     * Backfills activity for installations that predate most-recently-active ordering.
+     *
+     * Resolved through an [ObjectProvider] rather than `@ConditionalOnBean`: the condition is
+     * evaluated at auto-configuration parse time, so an application that registers its
+     * [PersistenceManager] from another auto-configuration or a `BeanFactoryPostProcessor`
+     * would silently get no runner — and un-backfilled sessions then vanish from every page
+     * after the first under [SessionOrder.LAST_ACTIVITY]. Absence is logged loudly instead.
+     */
     @Bean
-    @ConditionalOnBean(PersistenceManager::class)
     open fun chatStoreSessionActivityMigration(
-        persistenceManager: PersistenceManager,
+        persistenceManagers: ObjectProvider<PersistenceManager>,
     ): ApplicationRunner = ApplicationRunner {
-        SessionActivityMigration(persistenceManager).migrate()
+        val persistenceManager = persistenceManagers.getIfAvailable()
+        if (persistenceManager == null) {
+            logger.warn(
+                "No PersistenceManager bean: skipping the session activity backfill. Sessions " +
+                    "created before lastActivityAt existed will be missing from paged listings " +
+                    "ordered by ${SessionOrder.LAST_ACTIVITY}."
+            )
+        } else {
+            SessionActivityMigration(persistenceManager).migrate()
+        }
     }
 
     /**

--- a/embabel-chat-store/codegen-gradle/build.gradle.kts
+++ b/embabel-chat-store/codegen-gradle/build.gradle.kts
@@ -23,7 +23,7 @@ version = "0.5.0-SNAPSHOT"
 // later compiled against. Previously drivineVersion was hardcoded here, so bumping the pom silently
 // generated the DSL against a different Drivine than the one it compiled against. The fallbacks keep a
 // standalone `./gradlew kspKotlin` working.
-val drivineVersion = (findProperty("drivineVersion") as String?) ?: "0.0.74"
+val drivineVersion = (findProperty("drivineVersion") as String?) ?: "0.0.76"
 val embabelAgentVersion = (findProperty("embabelAgentVersion") as String?) ?: "1.5.0-SNAPSHOT"
 val embabelCommonVersion = (findProperty("embabelCommonVersion") as String?) ?: "2.0.0-SNAPSHOT"
 

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/adapter/StoredConversation.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/adapter/StoredConversation.kt
@@ -22,6 +22,7 @@ import com.embabel.chat.Message
 import com.embabel.chat.MessageRole
 import com.embabel.chat.event.MessageEvent
 import com.embabel.chat.store.embedding.MessageEmbedder
+import com.embabel.chat.store.event.MessagePersistedEvent
 import com.embabel.chat.store.event.SessionEventAwaiter
 import com.embabel.chat.store.model.AttachmentData
 import com.embabel.chat.store.model.MessageData
@@ -133,12 +134,31 @@ class StoredConversation(
      * @return the message (returned immediately, before persistence completes)
      */
     override fun addMessage(message: Message): Message {
+        addMessageWithId(message)
+        return message
+    }
+
+    /**
+     * Add a message and return the ID it is stored under, for callers that need to address it
+     * later — setting narration on it, for example.
+     *
+     * Deliberately NOT on the [com.embabel.chat.Conversation] interface, whose [addMessage]
+     * returns a [Message] and whose [Message] type carries no identity. The ID is minted here
+     * synchronously and is valid immediately, even though persistence is asynchronous; a
+     * subsequent update keyed by it will not find the message until the write lands, so prefer
+     * reacting to the PERSISTED [MessageEvent] where timing matters.
+     *
+     * @param message the message to add
+     * @param attachments files to attach; empty behaves exactly like [addMessage]
+     * @return the message ID
+     */
+    fun addMessageWithId(message: Message, attachments: List<AttachmentData> = emptyList()): String {
         val (from, to) = when (message.role) {
             MessageRole.USER -> user to agent
             MessageRole.ASSISTANT -> agent to user
             else -> null to user
         }
-        return addMessageInternal(message, from, to)
+        return addMessageInternal(message, from, to, attachments)
     }
 
     /**
@@ -159,12 +179,8 @@ class StoredConversation(
      * @return the message (returned immediately, before persistence completes)
      */
     fun addMessageWithAttachments(message: Message, attachments: List<AttachmentData>): Message {
-        val (from, to) = when (message.role) {
-            MessageRole.USER -> user to agent
-            MessageRole.ASSISTANT -> agent to user
-            else -> null to user
-        }
-        return addMessageInternal(message, from, to, attachments)
+        addMessageWithId(message, attachments)
+        return message
     }
 
     /**
@@ -187,7 +203,8 @@ class StoredConversation(
             MessageRole.ASSISTANT -> user
             else -> agent
         }
-        return addMessageInternal(message, from, to)
+        addMessageInternal(message, from, to)
+        return message
     }
 
     /**
@@ -208,7 +225,8 @@ class StoredConversation(
     ): Message {
         val fromUser = from?.toStoredUser("from")
         val toUser = to?.toStoredUser("to")
-        return addMessageInternal(message, fromUser, toUser)
+        addMessageInternal(message, fromUser, toUser)
+        return message
     }
 
     override fun last(n: Int): Conversation {
@@ -231,12 +249,13 @@ class StoredConversation(
             )
     }
 
+    /** Adds the message and returns the ID it will be stored under. */
     private fun addMessageInternal(
         message: Message,
         from: StoredUser?,
         to: StoredUser?,
         attachments: List<AttachmentData> = emptyList()
-    ): Message {
+    ): String {
         val messageData = MessageData.from(message, messageId = UUIDv7.generateString())
 
         // Generate an interim title from the first user message so the session
@@ -279,6 +298,11 @@ class StoredConversation(
                     val persistedMessage = updatedSession.messages.last().toMessage()
                     eventPublisher?.publishEvent(
                         MessageEvent.persisted(id, persistedMessage, from?.id, to?.id, title)
+                    )
+                    // Carries the message ID, which MessageEvent cannot: listeners doing
+                    // enrichment keyed by ID need to know the write has landed.
+                    eventPublisher?.publishEvent(
+                        MessagePersistedEvent(id, messageData.messageId, message.role)
                     )
                     logger.debug("Message {} persisted to session {}", messageData.messageId, id)
                 } catch (e: Exception) {
@@ -323,7 +347,7 @@ class StoredConversation(
             }
         }
 
-        return message
+        return messageData.messageId
     }
 
     /**

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/event/MessagePersistedEvent.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/event/MessagePersistedEvent.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.store.event
+
+import com.embabel.chat.MessageRole
+import java.time.Instant
+
+/**
+ * Published once a message has been written to the database, carrying the ID it was stored
+ * under.
+ *
+ * [com.embabel.chat.event.MessageEvent] conveys the same lifecycle but only ever carries a
+ * [com.embabel.chat.Message], which has no identity, so a listener has no way to address the
+ * message it was just told about. This event exists to close that gap: it is the point at
+ * which enrichment keyed by message ID — narration, for instance — is safe, because the
+ * message is known to be persisted rather than merely queued.
+ *
+ * @param sessionId the session the message belongs to
+ * @param messageId the ID the message was stored under
+ * @param role the role of the persisted message, so listeners can filter without a read
+ * @param timestamp when the event occurred
+ */
+data class MessagePersistedEvent(
+    val sessionId: String,
+    val messageId: String,
+    val role: MessageRole,
+    override val timestamp: Instant = Instant.now()
+) : ChatStoreEvent

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/model/SessionData.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/model/SessionData.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.chat.store.model
 
+import org.drivine.annotation.Default
 import org.drivine.annotation.NodeFragment
 import org.drivine.annotation.NodeId
 import org.drivine.annotation.RangeIndex
@@ -23,14 +24,18 @@ import java.time.Instant
 /**
  * Core session data stored as a Neo4j node.
  *
- * Sessions are identified by UUIDv7 which provides chronological ordering
- * when sorted lexicographically.
+ * Two orderings are supported over these properties, selected by
+ * [com.embabel.chat.store.repository.SessionOrder]: creation order via [sessionId], and
+ * most-recently-active order via [lastActivityAt] with [sessionId] as tie-breaker.
  */
 @NodeFragment(labels = ["ChatSession"])
 @RangeIndex(properties = ["lastActivityAt"])
 data class SessionData(
     /**
-     * Unique session identifier (UUIDv7 recommended).
+     * Unique session identifier. UUIDv7 is strongly recommended: it embeds its creation
+     * timestamp in the leading bits, so lexicographic order is creation order, which is what
+     * [com.embabel.chat.store.repository.SessionOrder.CREATED] paginates on. Any unique
+     * string still paginates deterministically, just not chronologically.
      */
     @NodeId val sessionId: String,
 
@@ -44,7 +49,19 @@ data class SessionData(
      */
     val createdAt: Instant,
 
-    /** Last user-visible conversation activity; used for stable session-list ordering. */
+    /**
+     * Last user-visible conversation activity, advanced only when a message is added —
+     * enrichment such as narration deliberately does not reorder sessions.
+     *
+     * [Default] makes a session stored before this property existed hydrate as [createdAt]
+     * rather than failing to load, so old data stays readable and orders sensibly under
+     * [com.embabel.chat.store.repository.SessionOrder.CREATED] with no migration at all.
+     * [com.embabel.chat.store.repository.SessionOrder.LAST_ACTIVITY] additionally needs the
+     * value materialised in the graph — a null never satisfies a keyset comparison — so
+     * [com.embabel.chat.store.repository.SessionActivityMigration] still backfills it, but as
+     * a correctness step for that one ordering rather than a prerequisite for reading at all.
+     */
+    @Default
     val lastActivityAt: Instant = createdAt,
 
     /**

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepository.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepository.kt
@@ -79,17 +79,28 @@ interface ChatSessionRepository {
      * List all sessions owned by a user.
      *
      * @param userId the owner's user ID
+     * @param order the sort order; defaults to newest-created first
      * @return list of sessions owned by the user
      */
-    fun listSessionsForUser(userId: String): List<StoredSession>
+    fun listSessionsForUser(
+        userId: String,
+        order: SessionOrder = SessionOrder.CREATED,
+    ): List<StoredSession>
 
     /**
-     * List sessions in descending `(lastActivityAt, sessionId)` order using an opaque keyset cursor.
-     * The session ID is only a unique tie-breaker: arbitrary strings remain deterministic, while
-     * UUIDv7 is still recommended by the creation API. Concurrent activity may move a session ahead
-     * of an already-issued cursor; this method does not provide snapshot isolation across requests.
+     * List one page of sessions in [SessionPageRequest.order], using an opaque keyset cursor.
+     *
+     * Under [SessionOrder.CREATED] the keyset is `sessionId` descending, which is creation order
+     * for UUIDv7 IDs; under [SessionOrder.LAST_ACTIVITY] it is `(lastActivityAt, sessionId)`
+     * descending, with the ID acting only as a unique tie-breaker. A cursor is bound to the order
+     * that issued it and is rejected if replayed against the other.
+     *
+     * There is no snapshot isolation across requests: under [SessionOrder.LAST_ACTIVITY],
+     * concurrent activity may move a session ahead of an already-issued cursor, so it can be seen
+     * twice or missed. [SessionOrder.CREATED] keys on an immutable value and so is stable.
      */
-    fun listSessionsForUser(userId: String, page: SessionPageRequest): SessionPage<StoredSession>
+    fun listSessionsForUser(userId: String, page: SessionPageRequest): SessionPage<StoredSession> =
+        SessionPaging.inMemory(listSessionsForUser(userId, page.order), page) { it.session }
 
     /**
      * List a user's sessions as lightweight summaries — owner plus a message count
@@ -97,14 +108,19 @@ interface ChatSessionRepository {
      * UIs that show a "N messages" badge but not the conversation bodies.
      *
      * @param userId the owner's user ID
+     * @param order the sort order; defaults to newest-created first
      * @return one [SessionSummary] per owned session
      */
-    fun listSessionSummariesForUser(userId: String): List<SessionSummary>
+    fun listSessionSummariesForUser(
+        userId: String,
+        order: SessionOrder = SessionOrder.CREATED,
+    ): List<SessionSummary>
 
     /**
      * Lightweight equivalent of [listSessionsForUser] with identical ordering and cursor semantics.
      */
-    fun listSessionSummariesForUser(userId: String, page: SessionPageRequest): SessionPage<SessionSummary>
+    fun listSessionSummariesForUser(userId: String, page: SessionPageRequest): SessionPage<SessionSummary> =
+        SessionPaging.inMemory(listSessionSummariesForUser(userId, page.order), page) { it.session }
 
     /**
      * Count the sessions owned by a user, without loading them.
@@ -170,12 +186,32 @@ interface ChatSessionRepository {
     // ==================== Message Updates ====================
 
     /**
+     * Set the narration text on a specific message.
+     *
+     * Narration is enrichment, not activity: it deliberately does not advance the session's
+     * `lastActivityAt`, so adding narration never reorders a session in a listing ordered by
+     * [SessionOrder.LAST_ACTIVITY], and never reorders the message within its thread.
+     *
+     * @param sessionId the session owning the message
+     * @param messageId the message to narrate, as minted when it was added
+     * @param narration the TTS-friendly narration text
+     * @return true if the message was found and updated, false otherwise
+     */
+    fun updateMessageNarration(sessionId: String, messageId: String, narration: String): Boolean
+
+    /**
      * Update the narration text for a message.
      * Finds the latest assistant message without narration in the given session.
      *
      * @param conversationId the session/conversation ID
      * @param narration the TTS-friendly narration text
      */
+    @Deprecated(
+        "Guesses which message to narrate, and races the asynchronous message write: a " +
+            "narration arriving before its message is persisted attaches to the previous " +
+            "un-narrated assistant message. Use the messageId-keyed overload.",
+        ReplaceWith("updateMessageNarration(conversationId, messageId, narration)"),
+    )
     fun updateMessageNarration(conversationId: String, narration: String)
 
     // ==================== Bulk Operations ====================

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImpl.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImpl.kt
@@ -135,34 +135,33 @@ open class ChatSessionRepositoryImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun listSessionsForUser(userId: String): List<StoredSession> {
-        val lastActivityOrder = StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.desc()
-        val sessionIdOrder = StoredSessionQueryDsl.INSTANCE.session.sessionId.desc()
+    override fun listSessionsForUser(userId: String, order: SessionOrder): List<StoredSession> {
+        val orders = storedSessionOrders(order)
         return graphObjectManager.loadAll<StoredSession> {
             where {
                 owner.id eq userId
             }
             orderBy {
-                registerOrder(lastActivityOrder)
-                registerOrder(sessionIdOrder)
+                orders.forEach { registerOrder(it) }
             }
         }
     }
 
     @Transactional(readOnly = true)
     override fun listSessionsForUser(userId: String, page: SessionPageRequest): SessionPage<StoredSession> {
-        val lastActivityOrder = StoredSessionQueryDsl.INSTANCE.session.lastActivityAt.desc()
-        val sessionIdOrder = StoredSessionQueryDsl.INSTANCE.session.sessionId.desc()
+        val orders = storedSessionOrders(page.order)
+        val cursor = page.cursor?.let { SessionCursorCodec.decode(it, page.order) }
         return loadSessionPage(page, loader = {
             graphObjectManager.loadAll<StoredSession> {
                 where { owner.id eq userId }
-                orderBy {
-                    registerOrder(lastActivityOrder)
-                    registerOrder(sessionIdOrder)
-                }
-                page.cursor?.let { encoded ->
-                    val cursor = SessionCursorCodec.decode(encoded)
-                    seek {
+                orderBy { orders.forEach { registerOrder(it) } }
+                when (cursor) {
+                    null -> Unit
+                    is SessionCursor.Created -> seek {
+                        query.session.sessionId after cursor.sessionId
+                    }
+
+                    is SessionCursor.LastActivity -> seek {
                         query.session.lastActivityAt after cursor.lastActivityAt
                         query.session.sessionId after cursor.sessionId
                     }
@@ -173,9 +172,8 @@ open class ChatSessionRepositoryImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun listSessionSummariesForUser(userId: String): List<SessionSummary> {
-        val lastActivityOrder = SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.desc()
-        val sessionIdOrder = SessionSummaryQueryDsl.INSTANCE.session.sessionId.desc()
+    override fun listSessionSummariesForUser(userId: String, order: SessionOrder): List<SessionSummary> {
+        val orders = sessionSummaryOrders(order)
         // SessionSummary folds the message count into the query (via @Count), so this
         // returns one flat row per session — no message bodies cross the wire.
         return graphObjectManager.loadAll<SessionSummary> {
@@ -183,8 +181,7 @@ open class ChatSessionRepositoryImpl(
                 owner.id eq userId
             }
             orderBy {
-                registerOrder(lastActivityOrder)
-                registerOrder(sessionIdOrder)
+                orders.forEach { registerOrder(it) }
             }
         }
     }
@@ -194,18 +191,19 @@ open class ChatSessionRepositoryImpl(
         userId: String,
         page: SessionPageRequest,
     ): SessionPage<SessionSummary> {
-        val lastActivityOrder = SessionSummaryQueryDsl.INSTANCE.session.lastActivityAt.desc()
-        val sessionIdOrder = SessionSummaryQueryDsl.INSTANCE.session.sessionId.desc()
+        val orders = sessionSummaryOrders(page.order)
+        val cursor = page.cursor?.let { SessionCursorCodec.decode(it, page.order) }
         return loadSessionPage(page, loader = {
             graphObjectManager.loadAll<SessionSummary> {
                 where { owner.id eq userId }
-                orderBy {
-                    registerOrder(lastActivityOrder)
-                    registerOrder(sessionIdOrder)
-                }
-                page.cursor?.let { encoded ->
-                    val cursor = SessionCursorCodec.decode(encoded)
-                    seek {
+                orderBy { orders.forEach { registerOrder(it) } }
+                when (cursor) {
+                    null -> Unit
+                    is SessionCursor.Created -> seek {
+                        query.session.sessionId after cursor.sessionId
+                    }
+
+                    is SessionCursor.LastActivity -> seek {
                         query.session.lastActivityAt after cursor.lastActivityAt
                         query.session.sessionId after cursor.sessionId
                     }
@@ -213,6 +211,27 @@ open class ChatSessionRepositoryImpl(
                 limit(page.pageSize + 1)
             }
         }, sessionData = { it.session })
+    }
+
+    /**
+     * Sort keys for [StoredSession] in the requested order. [SessionOrder.CREATED] needs no
+     * tie-breaker: the session ID is unique, so it is already a total order.
+     */
+    private fun storedSessionOrders(order: SessionOrder): List<OrderSpec> {
+        val session = StoredSessionQueryDsl.INSTANCE.session
+        return when (order) {
+            SessionOrder.CREATED -> listOf(session.sessionId.desc())
+            SessionOrder.LAST_ACTIVITY -> listOf(session.lastActivityAt.desc(), session.sessionId.desc())
+        }
+    }
+
+    /** Sort keys for [SessionSummary]; see [storedSessionOrders]. */
+    private fun sessionSummaryOrders(order: SessionOrder): List<OrderSpec> {
+        val session = SessionSummaryQueryDsl.INSTANCE.session
+        return when (order) {
+            SessionOrder.CREATED -> listOf(session.sessionId.desc())
+            SessionOrder.LAST_ACTIVITY -> listOf(session.lastActivityAt.desc(), session.sessionId.desc())
+        }
     }
 
     @Transactional(readOnly = true)
@@ -257,8 +276,11 @@ open class ChatSessionRepositoryImpl(
             messageData.messageId, sessionId, attachments.size,
         )
 
-        // Verify session exists — MERGE on SessionRef would silently create a bare node
-        if (graphObjectManager.load<SessionRef>(sessionId) == null) {
+        // Verify the session exists and advance its activity in a single statement — MERGE on
+        // SessionRef would silently create a bare node. Folding the two saves a round trip on
+        // the hottest write path, and both are writes in this transaction, so a failure below
+        // rolls the timestamp back along with the message.
+        if (!touchSession(sessionId, clock.instant())) {
             throw IllegalArgumentException("Session not found: $sessionId")
         }
 
@@ -272,7 +294,6 @@ open class ChatSessionRepositoryImpl(
             )
         )
         graphObjectManager.save(newMessage, CascadeType.PRESERVE)
-        advanceActivity(sessionId, clock.instant())
 
         return findBySessionId(sessionId).orElseThrow {
             IllegalStateException("Session not found after adding message: $sessionId")
@@ -292,6 +313,33 @@ open class ChatSessionRepositoryImpl(
         return graphObjectManager.load<SessionParticipants>(sessionId)?.participants ?: emptyList()
     }
 
+    @Transactional
+    override fun updateMessageNarration(sessionId: String, messageId: String, narration: String): Boolean {
+        val updated = persistenceManager.getOne(
+            QuerySpecification
+                .withStatement(
+                    """
+                    MATCH (:ChatSession {sessionId: ${'$'}sessionId})
+                          -[:HAS_MESSAGE]->(message:StoredMessage {messageId: ${'$'}messageId})
+                    SET message.narration = ${'$'}narration
+                    RETURN count(message) AS updated
+                    """.trimIndent()
+                )
+                .bind(mapOf("sessionId" to sessionId, "messageId" to messageId, "narration" to narration))
+                .map { (it as Number).toLong() }
+        )
+        if (updated == 0L) {
+            logger.warn("Cannot update narration: message {} not found in session {}", messageId, sessionId)
+            return false
+        }
+        logger.debug("Updated narration for message {} in session {}", messageId, sessionId)
+        return true
+    }
+
+    @Deprecated(
+        "Guesses which message to narrate; use the messageId-keyed overload",
+        ReplaceWith("updateMessageNarration(conversationId, messageId, narration)"),
+    )
     @Transactional
     override fun updateMessageNarration(conversationId: String, narration: String) {
         // Client-side filtering required: the DSL WHERE clause filters which sessions match,
@@ -320,20 +368,27 @@ open class ChatSessionRepositoryImpl(
         graphObjectManager.deleteAll<StoredSession> { }
     }
 
-    private fun advanceActivity(sessionId: String, activityAt: Instant) {
-        persistenceManager.execute(
-            QuerySpecification
-                .withStatement(
-                    """
-                    MATCH (session:ChatSession {sessionId: ${'$'}sessionId})
-                    SET session.lastActivityAt = CASE
-                        WHEN session.lastActivityAt IS NULL OR session.lastActivityAt < ${'$'}activityAt
-                        THEN ${'$'}activityAt ELSE session.lastActivityAt END
-                    """.trimIndent()
-                )
-                .bind(mapOf("sessionId" to sessionId, "activityAt" to activityAt))
-        )
-    }
+    /**
+     * Advance the session's activity timestamp, returning whether the session exists.
+     *
+     * The timestamp only ever moves forward, so clock skew between application instances can
+     * leave the ordering slightly stale but can never move a session backwards — which would
+     * otherwise let a keyset walk skip or repeat it.
+     */
+    private fun touchSession(sessionId: String, activityAt: Instant): Boolean = persistenceManager.getOne(
+        QuerySpecification
+            .withStatement(
+                """
+                MATCH (session:ChatSession {sessionId: ${'$'}sessionId})
+                SET session.lastActivityAt = CASE
+                    WHEN session.lastActivityAt IS NULL OR session.lastActivityAt < ${'$'}activityAt
+                    THEN ${'$'}activityAt ELSE session.lastActivityAt END
+                RETURN count(session) AS found
+                """.trimIndent()
+            )
+            .bind(mapOf("sessionId" to sessionId, "activityAt" to activityAt))
+            .map { (it as Number).toLong() }
+    ) > 0
 
     private fun <T> loadSessionPage(
         page: SessionPageRequest,
@@ -344,7 +399,7 @@ open class ChatSessionRepositoryImpl(
         val items = loaded.take(page.pageSize)
         val nextCursor = if (loaded.size > page.pageSize) {
             items.lastOrNull()?.let(sessionData)?.let {
-                SessionCursorCodec.encode(SessionCursor(it.lastActivityAt, it.sessionId))
+                SessionCursorCodec.encode(SessionPaging.cursorFor(page.order, it))
             }
         } else null
         return SessionPage(items, nextCursor)

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionActivityMigration.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionActivityMigration.kt
@@ -17,22 +17,95 @@ package com.embabel.chat.store.repository
 
 import org.drivine.manager.PersistenceManager
 import org.drivine.query.QuerySpecification
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
-/** Idempotently backfills activity timestamps for sessions created before activity ordering existed. */
+/**
+ * Backfills `lastActivityAt` for sessions created before activity ordering existed.
+ *
+ * Such sessions still read correctly without this — `SessionData.lastActivityAt` carries
+ * Drivine's `@Default` and hydrates as `createdAt` — but a value that exists only client-side
+ * cannot satisfy a keyset comparison, so under [SessionOrder.LAST_ACTIVITY] the session would
+ * be dropped from every page after the first. This materialises it in the graph, running
+ * until none are left and then recording a marker node, so the common case on subsequent
+ * boots is a single lookup rather than a full label scan.
+ *
+ * Work is done in bounded batches rather than one transaction: the un-backfilled set cannot
+ * use the `lastActivityAt` range index (Neo4j does not index nulls), so the first run on a
+ * large store would otherwise be a single long write transaction on startup.
+ */
 class SessionActivityMigration(
     private val persistenceManager: PersistenceManager,
+    private val batchSize: Int = DEFAULT_BATCH_SIZE,
 ) {
+    private val logger = LoggerFactory.getLogger(SessionActivityMigration::class.java)
+
     fun migrate() {
-        persistenceManager.execute(
-            QuerySpecification.withStatement(
+        if (isComplete()) {
+            logger.debug("Session activity backfill already complete")
+            return
+        }
+        var total = 0L
+        do {
+            val updated = backfillBatch()
+            total += updated
+            if (updated > 0) {
+                logger.info("Backfilled lastActivityAt for {} sessions ({} total)", updated, total)
+            }
+        } while (updated > 0)
+        markComplete()
+        if (total > 0) {
+            logger.info("Session activity backfill complete: {} sessions updated", total)
+        }
+    }
+
+    /**
+     * Backfill at most [batchSize] sessions, returning how many were updated.
+     *
+     * The coalesce falls back to [Instant.EPOCH] so that a legacy session with neither
+     * messages nor a `createdAt` still gets a value. Without that floor the SET would be
+     * null, which in Cypher *removes* the property, leaving the session matching the same
+     * filter forever and preventing the migration from ever converging.
+     */
+    private fun backfillBatch(): Long = persistenceManager.getOne(
+        QuerySpecification
+            .withStatement(
                 """
                 MATCH (session:ChatSession)
                 WHERE session.lastActivityAt IS NULL
+                WITH session LIMIT ${'$'}batchSize
                 OPTIONAL MATCH (session)-[:HAS_MESSAGE]->(message:StoredMessage)
                 WITH session, max(message.createdAt) AS latestMessageAt
-                SET session.lastActivityAt = coalesce(latestMessageAt, session.createdAt)
+                SET session.lastActivityAt = coalesce(latestMessageAt, session.createdAt, ${'$'}floor)
+                RETURN count(session) AS updated
                 """.trimIndent()
             )
+            .bind(mapOf("batchSize" to batchSize, "floor" to Instant.EPOCH))
+            .map { (it as Number).toLong() }
+    )
+
+    private fun isComplete(): Boolean = persistenceManager.getOne(
+        QuerySpecification
+            .withStatement(
+                "MATCH (m:`$MARKER_LABEL` {name: \$name}) RETURN count(m) AS found"
+            )
+            .bind(mapOf("name" to MARKER_NAME))
+            .map { (it as Number).toLong() }
+    ) > 0
+
+    private fun markComplete() {
+        persistenceManager.execute(
+            QuerySpecification
+                .withStatement(
+                    "MERGE (m:`$MARKER_LABEL` {name: \$name}) SET m.completedAt = timestamp()"
+                )
+                .bind(mapOf("name" to MARKER_NAME))
         )
+    }
+
+    companion object {
+        const val DEFAULT_BATCH_SIZE = 1000
+        private const val MARKER_LABEL = "_ChatStoreMigration"
+        private const val MARKER_NAME = "session-activity"
     }
 }

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionCursor.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionCursor.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.store.repository
+
+import java.time.Instant
+
+/**
+ * The decoded position of a page boundary: the keyset values of the last item returned.
+ *
+ * One variant per [SessionOrder], because the keyset differs. Callers see only the opaque
+ * encoded form produced by [SessionCursorCodec]; the [order] is carried so that a cursor
+ * issued under one ordering is rejected rather than silently seeking on the wrong key.
+ */
+internal sealed interface SessionCursor {
+
+    val order: SessionOrder
+
+    val sessionId: String
+
+    /** Position in [SessionOrder.CREATED]: the session ID is the whole keyset. */
+    data class Created(
+        override val sessionId: String,
+    ) : SessionCursor {
+        override val order: SessionOrder get() = SessionOrder.CREATED
+    }
+
+    /** Position in [SessionOrder.LAST_ACTIVITY]: activity timestamp, session ID as tie-breaker. */
+    data class LastActivity(
+        val lastActivityAt: Instant,
+        override val sessionId: String,
+    ) : SessionCursor {
+        override val order: SessionOrder get() = SessionOrder.LAST_ACTIVITY
+    }
+}

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionCursorCodec.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionCursorCodec.kt
@@ -20,51 +20,67 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util.Base64
 
-internal data class SessionCursor(
-    val lastActivityAt: Instant,
-    val sessionId: String,
-)
-
-/** Versioned binary cursor encoding; callers treat the resulting Base64URL value as opaque. */
+/**
+ * Versioned binary cursor encoding; callers treat the resulting Base64URL value as opaque.
+ *
+ * The payload carries the [SessionOrder] it was issued under. [decode] requires the caller to
+ * state the order it is about to seek on and rejects a mismatch, because the two orderings
+ * key on different properties: replaying a cursor against the wrong ordering would otherwise
+ * seek on the wrong value and silently return a wrong page rather than an error.
+ */
 internal object SessionCursorCodec {
     private const val VERSION: Byte = 1
-    private const val HEADER_SIZE = 1 + Long.SIZE_BYTES + Int.SIZE_BYTES + Int.SIZE_BYTES
     private const val MAX_SESSION_ID_BYTES = 16 * 1024
 
     fun encode(cursor: SessionCursor): String {
         val idBytes = cursor.sessionId.toByteArray(StandardCharsets.UTF_8)
         require(idBytes.size <= MAX_SESSION_ID_BYTES) { "sessionId is too large to encode in a cursor" }
-        val bytes = ByteBuffer.allocate(HEADER_SIZE + idBytes.size)
+        val timestampSize = if (cursor is SessionCursor.LastActivity) Long.SIZE_BYTES + Int.SIZE_BYTES else 0
+        val buffer = ByteBuffer.allocate(2 + timestampSize + Int.SIZE_BYTES + idBytes.size)
             .put(VERSION)
-            .putLong(cursor.lastActivityAt.epochSecond)
-            .putInt(cursor.lastActivityAt.nano)
-            .putInt(idBytes.size)
-            .put(idBytes)
-            .array()
+            .put(cursor.order.ordinal.toByte())
+        if (cursor is SessionCursor.LastActivity) {
+            buffer.putLong(cursor.lastActivityAt.epochSecond).putInt(cursor.lastActivityAt.nano)
+        }
+        val bytes = buffer.putInt(idBytes.size).put(idBytes).array()
         return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
     }
 
-    fun decode(encoded: String): SessionCursor {
+    fun decode(encoded: String, expectedOrder: SessionOrder): SessionCursor {
         try {
-            val bytes = Base64.getUrlDecoder().decode(encoded)
-            require(bytes.size >= HEADER_SIZE) { "cursor payload is truncated" }
-            val buffer = ByteBuffer.wrap(bytes)
+            val buffer = ByteBuffer.wrap(Base64.getUrlDecoder().decode(encoded))
+            require(buffer.remaining() >= 2) { "cursor payload is truncated" }
             require(buffer.get() == VERSION) { "unsupported cursor version" }
-            val epochSecond = buffer.long
-            val nano = buffer.int
-            require(nano in 0..999_999_999) { "invalid cursor timestamp" }
-            val idLength = buffer.int
-            require(idLength in 0..MAX_SESSION_ID_BYTES && idLength == buffer.remaining()) {
-                "invalid cursor session ID length"
+            val order = buffer.get().toInt().let { ordinal ->
+                require(ordinal in SessionOrder.entries.indices) { "unknown cursor ordering" }
+                SessionOrder.entries[ordinal]
             }
-            val idBytes = ByteArray(idLength)
-            buffer.get(idBytes)
-            val sessionId = String(idBytes, StandardCharsets.UTF_8)
-            require(sessionId.isNotEmpty()) { "cursor session ID is empty" }
-            return SessionCursor(Instant.ofEpochSecond(epochSecond, nano.toLong()), sessionId)
+            require(order == expectedOrder) {
+                "cursor was issued for $order but this request orders by $expectedOrder"
+            }
+            return when (order) {
+                SessionOrder.CREATED -> SessionCursor.Created(readSessionId(buffer))
+                SessionOrder.LAST_ACTIVITY -> {
+                    require(buffer.remaining() >= Long.SIZE_BYTES + Int.SIZE_BYTES) { "cursor payload is truncated" }
+                    val epochSecond = buffer.long
+                    val nano = buffer.int
+                    require(nano in 0..999_999_999) { "invalid cursor timestamp" }
+                    SessionCursor.LastActivity(Instant.ofEpochSecond(epochSecond, nano.toLong()), readSessionId(buffer))
+                }
+            }
         } catch (cause: Exception) {
-            if (cause is IllegalArgumentException && cause.message == "Invalid session cursor") throw cause
             throw IllegalArgumentException("Invalid session cursor", cause)
         }
+    }
+
+    private fun readSessionId(buffer: ByteBuffer): String {
+        require(buffer.remaining() >= Int.SIZE_BYTES) { "cursor payload is truncated" }
+        val idLength = buffer.int
+        require(idLength in 1..MAX_SESSION_ID_BYTES && idLength == buffer.remaining()) {
+            "invalid cursor session ID length"
+        }
+        val idBytes = ByteArray(idLength)
+        buffer.get(idBytes)
+        return String(idBytes, StandardCharsets.UTF_8)
     }
 }

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionOrder.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionOrder.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.store.repository
+
+/**
+ * The order in which sessions are listed, and correspondingly the keyset a page cursor
+ * seeks on. A cursor is only valid for the order that produced it.
+ */
+enum class SessionOrder {
+
+    /**
+     * Newest-created first.
+     *
+     * Keys on `sessionId` alone. A UUIDv7 session ID embeds its creation timestamp in the
+     * leading bits, and its canonical string form is big-endian hex, so lexicographic
+     * comparison is chronological comparison. The ID is unique, so this is already a total
+     * order and needs no tie-breaker, and it is backed by the index behind the `sessionId`
+     * uniqueness constraint.
+     *
+     * Creation order is immutable and always present, so this ordering is unaffected by the
+     * `lastActivityAt` backfill and is the default. A non-UUIDv7 session ID still paginates
+     * deterministically, just not chronologically.
+     */
+    CREATED,
+
+    /**
+     * Most recently active first, `sessionId` descending as tie-breaker.
+     *
+     * Activity advances only when a message is added; enrichment such as narration does not
+     * reorder sessions.
+     *
+     * Requires `lastActivityAt` to be materialised in the graph on every session. A value
+     * supplied only by the model's `@Default` is not enough: it satisfies hydration but not
+     * the keyset comparison, so such a session would still drop out of every page after the
+     * first. [SessionActivityMigration] backfills installations that predate this ordering.
+     */
+    LAST_ACTIVITY,
+}

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionPage.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionPage.kt
@@ -15,25 +15,12 @@
  */
 package com.embabel.chat.store.repository
 
-/** Request for one cursor-based page of sessions. */
-data class SessionPageRequest(
-    val pageSize: Int = DEFAULT_PAGE_SIZE,
-    val cursor: String? = null,
-) {
-    init {
-        require(pageSize in 1..MAX_PAGE_SIZE) {
-            "pageSize must be between 1 and $MAX_PAGE_SIZE, was $pageSize"
-        }
-        require(cursor == null || cursor.isNotBlank()) { "cursor must be null or non-blank" }
-    }
-
-    companion object {
-        const val DEFAULT_PAGE_SIZE = 20
-        const val MAX_PAGE_SIZE = 100
-    }
-}
-
-/** A page of sessions and the opaque cursor for the following page, if one exists. */
+/**
+ * A page of sessions and the opaque cursor for the following page.
+ *
+ * [nextCursor] is null when this is the last page. It encodes the ordering that produced it,
+ * so it must be passed back with the same [SessionOrder].
+ */
 data class SessionPage<T>(
     val items: List<T>,
     val nextCursor: String?,

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionPageRequest.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionPageRequest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.store.repository
+
+/**
+ * Request for one cursor-based page of sessions.
+ *
+ * [order] must stay the same across every page of a walk: a [cursor] is only valid for the
+ * ordering that issued it, and pairing it with a different one is rejected.
+ */
+data class SessionPageRequest(
+    val pageSize: Int = DEFAULT_PAGE_SIZE,
+    val cursor: String? = null,
+    val order: SessionOrder = SessionOrder.CREATED,
+) {
+    init {
+        require(pageSize in 1..MAX_PAGE_SIZE) {
+            "pageSize must be between 1 and $MAX_PAGE_SIZE, was $pageSize"
+        }
+        require(cursor == null || cursor.isNotBlank()) { "cursor must be null or non-blank" }
+    }
+
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 20
+        const val MAX_PAGE_SIZE = 100
+    }
+}

--- a/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionPaging.kt
+++ b/embabel-chat-store/src/main/kotlin/com/embabel/chat/store/repository/SessionPaging.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.store.repository
+
+import com.embabel.chat.store.model.SessionData
+
+/**
+ * Client-side keyset paging over an already-ordered list.
+ *
+ * Backs the default [ChatSessionRepository] paging methods so that in-memory implementations
+ * and test doubles inherit correct cursor semantics for free. It loads every session to return
+ * one page, so a database-backed implementation should override those methods and push the
+ * keyset into the query instead — as [ChatSessionRepositoryImpl] does.
+ */
+internal object SessionPaging {
+
+    fun <T> inMemory(ordered: List<T>, page: SessionPageRequest, sessionData: (T) -> SessionData): SessionPage<T> {
+        val cursor = page.cursor?.let { SessionCursorCodec.decode(it, page.order) }
+        val remaining = if (cursor == null) {
+            ordered
+        } else {
+            ordered.dropWhile { !isAfter(sessionData(it), cursor) }
+        }
+        val items = remaining.take(page.pageSize)
+        val nextCursor = if (remaining.size > page.pageSize) {
+            items.lastOrNull()?.let(sessionData)?.let { SessionCursorCodec.encode(cursorFor(page.order, it)) }
+        } else null
+        return SessionPage(items, nextCursor)
+    }
+
+    fun cursorFor(order: SessionOrder, data: SessionData): SessionCursor = when (order) {
+        SessionOrder.CREATED -> SessionCursor.Created(data.sessionId)
+        SessionOrder.LAST_ACTIVITY -> SessionCursor.LastActivity(data.lastActivityAt, data.sessionId)
+    }
+
+    /** Whether [data] falls strictly after [cursor] in the cursor's descending order. */
+    private fun isAfter(data: SessionData, cursor: SessionCursor): Boolean = when (cursor) {
+        is SessionCursor.Created -> data.sessionId < cursor.sessionId
+        is SessionCursor.LastActivity -> when {
+            data.lastActivityAt != cursor.lastActivityAt -> data.lastActivityAt < cursor.lastActivityAt
+            else -> data.sessionId < cursor.sessionId
+        }
+    }
+}

--- a/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImplTest.kt
+++ b/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/repository/ChatSessionRepositoryImplTest.kt
@@ -20,6 +20,7 @@ import com.embabel.chat.store.TestApplication
 import com.embabel.chat.store.model.AttachmentData
 import com.embabel.chat.store.model.MessageData
 import com.embabel.chat.store.model.TestSessionUser
+import com.embabel.chat.store.util.UUIDv7
 import org.drivine.manager.GraphObjectManager
 import org.drivine.manager.PersistenceManager
 import org.drivine.query.QuerySpecification
@@ -101,14 +102,17 @@ class ChatSessionRepositoryImplTest {
             setActivity(id, activity)
         }
 
-        val first = chatSessionRepository.listSessionsForUser(testUser.id, SessionPageRequest(pageSize = 2))
+        val first = chatSessionRepository.listSessionsForUser(
+            testUser.id,
+            SessionPageRequest(pageSize = 2, order = SessionOrder.LAST_ACTIVITY),
+        )
         val second = chatSessionRepository.listSessionsForUser(
             testUser.id,
-            SessionPageRequest(pageSize = 2, cursor = first.nextCursor),
+            SessionPageRequest(pageSize = 2, cursor = first.nextCursor, order = SessionOrder.LAST_ACTIVITY),
         )
         val third = chatSessionRepository.listSessionsForUser(
             testUser.id,
-            SessionPageRequest(pageSize = 2, cursor = second.nextCursor),
+            SessionPageRequest(pageSize = 2, cursor = second.nextCursor, order = SessionOrder.LAST_ACTIVITY),
         )
 
         assertEquals(listOf("session-c", "session-b"), first.items.map { it.session.sessionId })
@@ -132,16 +136,89 @@ class ChatSessionRepositoryImplTest {
 
         val first = chatSessionRepository.listSessionSummariesForUser(
             testUser.id,
-            SessionPageRequest(pageSize = 1),
+            SessionPageRequest(pageSize = 1, order = SessionOrder.LAST_ACTIVITY),
         )
         val second = chatSessionRepository.listSessionSummariesForUser(
             testUser.id,
-            SessionPageRequest(pageSize = 1, cursor = first.nextCursor),
+            SessionPageRequest(pageSize = 1, cursor = first.nextCursor, order = SessionOrder.LAST_ACTIVITY),
         )
 
         assertEquals(listOf("mine-new"), first.items.map { it.session.sessionId })
         assertEquals(listOf("mine-old"), second.items.map { it.session.sessionId })
         assertNull(second.nextCursor)
+    }
+
+    @Test
+    fun `pages by creation order on session ID by default, ignoring activity`() {
+        val ids = List(5) { UUIDv7.generateString() }
+        ids.forEach { chatSessionRepository.createSession(it, testUser, it) }
+        // Activity deliberately contradicts creation order: the default must not follow it.
+        setActivity(ids[0], Instant.parse("2026-01-01T00:00:09Z"))
+        setActivity(ids[4], Instant.parse("2026-01-01T00:00:00Z"))
+
+        val first = chatSessionRepository.listSessionsForUser(testUser.id, SessionPageRequest(pageSize = 2))
+        val second = chatSessionRepository.listSessionsForUser(
+            testUser.id,
+            SessionPageRequest(pageSize = 2, cursor = first.nextCursor),
+        )
+        val third = chatSessionRepository.listSessionsForUser(
+            testUser.id,
+            SessionPageRequest(pageSize = 2, cursor = second.nextCursor),
+        )
+
+        val newestFirst = ids.sortedDescending()
+        assertEquals(newestFirst.subList(0, 2), first.items.map { it.session.sessionId })
+        assertEquals(newestFirst.subList(2, 4), second.items.map { it.session.sessionId })
+        assertEquals(newestFirst.subList(4, 5), third.items.map { it.session.sessionId })
+        assertNull(third.nextCursor)
+    }
+
+    @Test
+    fun `a session with no activity timestamp still reads, defaulting to its creation time`() {
+        val sessionId = UUIDv7.generateString()
+        val session = chatSessionRepository.createSession(sessionId, testUser)
+        persistenceManager.execute(
+            QuerySpecification.withStatement(
+                "MATCH (s:ChatSession {sessionId: \$id}) REMOVE s.lastActivityAt"
+            ).bind(mapOf("id" to sessionId))
+        )
+
+        // @Default on SessionData.lastActivityAt: a node predating the property hydrates as
+        // createdAt rather than failing, so old data needs no migration merely to be read.
+        val page = chatSessionRepository.listSessionsForUser(testUser.id, SessionPageRequest(pageSize = 10))
+
+        val loaded = page.items.single { it.session.sessionId == sessionId }
+        assertEquals(session.session.createdAt, loaded.session.lastActivityAt)
+    }
+
+    @Test
+    fun `the migration restores readability of a session with no activity timestamp`() {
+        val sessionId = UUIDv7.generateString()
+        chatSessionRepository.createSession(sessionId, testUser)
+        persistenceManager.execute(
+            QuerySpecification.withStatement(
+                "MATCH (s:ChatSession {sessionId: \$id}) SET s.lastActivityAt = null"
+            ).bind(mapOf("id" to sessionId))
+        )
+
+        SessionActivityMigration(persistenceManager).migrate()
+
+        val page = chatSessionRepository.listSessionsForUser(testUser.id, SessionPageRequest(pageSize = 10))
+        assertTrue(page.items.any { it.session.sessionId == sessionId })
+    }
+
+    @Test
+    fun `a cursor issued for one ordering is rejected by the other`() {
+        chatSessionRepository.createSession(UUIDv7.generateString(), testUser)
+        chatSessionRepository.createSession(UUIDv7.generateString(), testUser)
+        val createdPage = chatSessionRepository.listSessionsForUser(testUser.id, SessionPageRequest(pageSize = 1))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            chatSessionRepository.listSessionsForUser(
+                testUser.id,
+                SessionPageRequest(pageSize = 1, cursor = createdPage.nextCursor, order = SessionOrder.LAST_ACTIVITY),
+            )
+        }
     }
 
     @Test
@@ -532,6 +609,49 @@ class ChatSessionRepositoryImplTest {
                 .bind(mapOf("id" to id))
                 .transform(Int::class.java)
         )
+
+    @Test
+    fun `narration targets the given message and does not advance activity`() {
+        val sessionId = UUIDv7.generateString()
+        chatSessionRepository.createSession(sessionId, testUser)
+        val first = UUIDv7.generateString()
+        val second = UUIDv7.generateString()
+        chatSessionRepository.addMessage(
+            sessionId,
+            MessageData(first, MessageRole.ASSISTANT, "first", Instant.parse("2026-01-01T00:00:00Z")),
+        )
+        chatSessionRepository.addMessage(
+            sessionId,
+            MessageData(second, MessageRole.ASSISTANT, "second", Instant.parse("2026-01-01T00:00:01Z")),
+        )
+        val activityBefore = chatSessionRepository.findBySessionId(sessionId).get().session.lastActivityAt
+
+        // The older message, which the previous "latest un-narrated assistant" heuristic
+        // could never have reached.
+        assertTrue(chatSessionRepository.updateMessageNarration(sessionId, first, "spoken form"))
+
+        val messages = chatSessionRepository.getMessages(sessionId).associateBy { it.messageId }
+        assertEquals("spoken form", messages[first]?.narration)
+        assertNull(messages[second]?.narration)
+        assertEquals(
+            activityBefore,
+            chatSessionRepository.findBySessionId(sessionId).get().session.lastActivityAt,
+            "narration is enrichment, not activity",
+        )
+    }
+
+    @Test
+    fun `narration reports a miss rather than narrating the wrong message`() {
+        val sessionId = UUIDv7.generateString()
+        chatSessionRepository.createSession(sessionId, testUser)
+        chatSessionRepository.addMessage(
+            sessionId,
+            MessageData(UUIDv7.generateString(), MessageRole.ASSISTANT, "only", Instant.parse("2026-01-01T00:00:00Z")),
+        )
+
+        assertFalse(chatSessionRepository.updateMessageNarration(sessionId, UUIDv7.generateString(), "nope"))
+        assertTrue(chatSessionRepository.getMessages(sessionId).all { it.narration == null })
+    }
 
     private fun setActivity(sessionId: String, activityAt: Instant) {
         persistenceManager.execute(

--- a/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/repository/SessionCursorCodecTest.kt
+++ b/embabel-chat-store/src/test/kotlin/com/embabel/chat/store/repository/SessionCursorCodecTest.kt
@@ -23,16 +23,41 @@ import java.time.Instant
 class SessionCursorCodecTest {
 
     @Test
-    fun `cursor round trips timestamp precision and arbitrary session IDs`() {
-        val cursor = SessionCursor(Instant.parse("2026-08-04T12:34:56.123456789Z"), "not-a-uuid/✓")
+    fun `activity cursor round trips timestamp precision and arbitrary session IDs`() {
+        val cursor = SessionCursor.LastActivity(Instant.parse("2026-08-04T12:34:56.123456789Z"), "not-a-uuid/✓")
 
-        assertEquals(cursor, SessionCursorCodec.decode(SessionCursorCodec.encode(cursor)))
+        assertEquals(
+            cursor,
+            SessionCursorCodec.decode(SessionCursorCodec.encode(cursor), SessionOrder.LAST_ACTIVITY),
+        )
+    }
+
+    @Test
+    fun `created cursor round trips arbitrary session IDs`() {
+        val cursor = SessionCursor.Created("not-a-uuid/✓")
+
+        assertEquals(cursor, SessionCursorCodec.decode(SessionCursorCodec.encode(cursor), SessionOrder.CREATED))
+    }
+
+    @Test
+    fun `a cursor is rejected when replayed against the other ordering`() {
+        val encoded = SessionCursorCodec.encode(SessionCursor.Created("01931f00-0000-7000-8000-000000000000"))
+
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            SessionCursorCodec.decode(encoded, SessionOrder.LAST_ACTIVITY)
+        }
+
+        assertEquals("Invalid session cursor", exception.message)
+        assertEquals(
+            "cursor was issued for CREATED but this request orders by LAST_ACTIVITY",
+            exception.cause?.message,
+        )
     }
 
     @Test
     fun `malformed cursors fail with a stable public error`() {
         val exception = assertThrows(IllegalArgumentException::class.java) {
-            SessionCursorCodec.decode("not a cursor")
+            SessionCursorCodec.decode("not a cursor", SessionOrder.CREATED)
         }
 
         assertEquals("Invalid session cursor", exception.message)

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </modules>
 
     <properties>
-        <drivine.version>0.0.74</drivine.version>
+        <drivine.version>0.0.76</drivine.version>
         <embabel-common.version>2.0.0-SNAPSHOT</embabel-common.version>
         <embabel-agent.version>1.5.0-SNAPSHOT</embabel-agent.version>
         <!-- Overrides the parent's default (2.2.21): the Drivine KSP-generated DSL uses context


### PR DESCRIPTION
Follow-up to #15. Adds creation-ordered pagination, fixes the narration targeting bug, documents sorting, and addresses the review findings on #15.

## Sorting and pagination

`SessionOrder` selects the ordering, and **`CREATED` is now the default**:

| `SessionOrder`  | Keyset                        | Meaning                        |
|-----------------|-------------------------------|--------------------------------|
| `CREATED`       | `sessionId`                   | Newest-created first (default) |
| `LAST_ACTIVITY` | `(lastActivityAt, sessionId)` | Most recently active first     |

`CREATED` keys on the UUIDv7 session ID alone — its leading 48 bits are a timestamp and the canonical string form is big-endian hex, so lexicographic order is chronological order. The ID is unique, so this is already a total order needing no tie-breaker, and it is served by the index backing the `sessionId` uniqueness constraint: no new index, no migration, no null hazard.

Applied to the unpaged list methods too. Those had no defined ordering before #15, so nothing regresses.

**Cursors are now bound to their ordering.** `SessionCursor` is sealed per ordering and the codec writes an order discriminator, so replaying a cursor against the other ordering is rejected rather than silently seeking on the wrong property and returning a plausible-but-wrong page. Landing this before any cursor is issued to a client avoids a format migration later.

## Narration keyed by message ID

`updateMessageNarration(sessionId, messageId, narration): Boolean` replaces guessing at "the latest assistant message without narration". The old method loaded every message in the session client-side, and raced the asynchronous message write — a narration arriving before its message was persisted attached to the *previous* message. It is now `@Deprecated` explaining that.

Callers get the ID two ways, neither of which needs an upstream change:

- `StoredConversation.addMessageWithId(...)` returns the minted UUIDv7. `Conversation.addMessage` returns a `Message`, which carries no identity, so this is a non-override method alongside it — the pattern `addMessageWithAttachments` already established.
- A new `MessagePersistedEvent(sessionId, messageId, role)` fires once the write lands. This is the race-free hook for async TTS: the event *is* persistence.

Narration deliberately does **not** advance `lastActivityAt`. Enrichment shouldn't reorder a session in a listing any more than it should reorder a message within its thread.

## Review findings from #15

- **Null `lastActivityAt`.** `SessionData.lastActivityAt` now carries Drivine's `@Default`, so a session stored before the property existed hydrates as its `createdAt` instead of failing to load. This was the real defect: such a session was unreadable by *every* query, not merely mis-sorted. `LAST_ACTIVITY` still needs the value materialised in the graph, so the backfill remains — but as a correctness step for one ordering, not a prerequisite for reading.
- **Migration convergence.** Coalesces to an epoch floor, so a legacy session with neither messages nor a `createdAt` no longer has the property *removed* (Cypher `SET p = null` deletes it) and match the filter forever.
- **Migration cost.** Bounded batches instead of one unbatched full-label scan per boot, plus a marker node so later boots cost a single lookup. The un-backfilled set cannot use the range index, since Neo4j does not index nulls.
- **Silent migration skip.** `@ConditionalOnBean(PersistenceManager::class)` is evaluated at auto-configuration parse time, so an app registering its `PersistenceManager` from another auto-configuration got no runner and no warning. Now resolved via `ObjectProvider`, logging loudly when absent.
- **Round trip on the write path.** `addMessage` folded the existence check and the activity advance into one statement, dropping one AU round trip from the hottest path. Both are writes in the same transaction, so a failure rolls them back together.
- **Source compatibility.** The new paged `ChatSessionRepository` methods have default implementations backed by `SessionPaging`, so downstream implementors and test doubles inherit correct cursor semantics instead of failing to compile.
- Dead branch removed from `SessionCursorCodec`; stale `SessionData` KDoc corrected; `SessionPage.kt` and `SessionCursorCodec.kt` split to one type per file.

## Also

- Drivine `0.0.74` → `0.0.76`, in `pom.xml` and `codegen-gradle/build.gradle.kts` together.
- README gains a Sorting and Pagination section: both orderings, what counts as activity, a keyset paging example, cursor opacity, and the upgrade path.

## Notes for review

Two claims from the review of #15 did not survive contact with the code:

1. A missing `lastActivityAt` does **not** hydrate as `createdAt` and corrupt cursors — Drivine refuses to hydrate the node at all. Loud rather than silent, but broader in impact. `@Default` is the fix.
2. Constructor source compatibility for `ChatSessionRepositoryImpl` is unachievable: `persistenceManager` is genuinely required, so no overload can rescue a two-arg call site. A compatibility constructor was tried and dropped.

## Testing

96 tests pass against Neo4j and published drivine `0.0.76`. New coverage: creation-order paging with contradicting activity timestamps, cross-ordering cursor rejection, narration targeting an older message, narration reporting a miss, `@Default` hydration of a session with the property removed, and the migration restoring it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
