### PR TITLE
Build against drivine4j 0.0.79

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </modules>
 
     <properties>
-        <drivine.version>0.0.76</drivine.version>
+        <drivine.version>0.0.79</drivine.version>
         <embabel-common.version>2.0.0-SNAPSHOT</embabel-common.version>
         <embabel-agent.version>1.5.0-SNAPSHOT</embabel-agent.version>
         <!-- Overrides the parent's default (2.2.21): the Drivine KSP-generated DSL uses context


### PR DESCRIPTION
drivine4j 0.0.79 changed the `VectorIndexSpec` constructor (new engine vector
options — quantization/HNSW parameters — with Kotlin default values but no
`@JvmOverloads`), so the old 5-arg signature no longer exists in the binary.

Any host resolving drivine 0.0.79 transitively (e.g. via embabel-agent-rag-graph
0.4.0-SNAPSHOT) while consuming the current chat-store snapshot fails at boot:

    ChatStoreAutoConfiguration.chatStoreVectorIndexSchema(ChatStoreAutoConfiguration.kt:224)
    'void org.drivine.schema.VectorIndexSpec.<init>(String, String, int, SimilarityFunction, String)'

The source is already compatible — the Kotlin call site picks up the new
defaulted parameters — so the fix is only the dependency pin, letting CI publish
a snapshot built against the current binary. Full test suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9t8eRKuhBBNavdDpy15i4